### PR TITLE
tsconfig.json のパス判定方法を修正

### DIFF
--- a/libs/common.js
+++ b/libs/common.js
@@ -3,7 +3,7 @@ const path = require('path')
 const fs = require('fs')
 
 const replacePaths = (() => {
-  const tsconfig = fs.readFileSync(`${process.env.PWD}/tsconfig.json`)
+  const tsconfig = fs.readFileSync(`${process.cwd()}/tsconfig.json`)
 
   if (!tsconfig) {
     return null 
@@ -34,7 +34,7 @@ const rootPath = (() => {
     return ''
   }
 
-  return path.resolve(`${process.env.PWD}/${p.replace(/\/\*$/, '')}`)
+  return path.resolve(`${process.cwd()}/${p.replace(/\/\*$/, '')}`)
 })()
 
 module.exports = { replacePaths, rootPath }


### PR DESCRIPTION
VSCode の [ESLint Plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) をインストールし、validate を有効にしたところ以下のエラーが発生しました。

```
[Error - 7:51:55 PM] Error: Failed to load plugin 'eslint-plugin-smarthr' declared in '.eslintrc.js » eslint-config-smarthr': ENOENT: no such file or directory, open '/home/f440/tsconfig.json'
Referenced from: /xxx/xxx/xxx/xxx/xxx/node_modules/eslint-config-smarthr/index.js
    at Object.openSync (fs.js:476:3)
    at Object.readFileSync (fs.js:377:35)
```

Spotlight などで VSCode を起動した場合、環境変数 `PWD` はホームディレクトリになり、tsconfig.json が見つけられず上記エラーになっているようです。実際にプロセスが動いているディレクトリを取得するようにして対処しました。