### PR TITLE
BREAKING CHANGE: テストを適用可能にするため、function optionを取り除く

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,27 +314,6 @@ import { PrimaryButton, SecondaryButton } from 'smarthr-ui'
     - type のみ指定出来ます
     - type のsuffixを指定します
 
-#### 指定例
-```
-const ignorekeywords = ['views', 'parts']
-const betterNames = {
-  '\/repositories\/': {
-    file: {
-      operator: '-',
-      names: ['repository', 'Repository'],
-    },
-    variable: {
-      operator: '=',
-      names: ['repository'],
-    },
-    type: {
-      operator: '+',
-      names: ['Props'],
-    },
-  },
-}
-```
-
 #### ファイル例
 - `@/crews/index/views/page.tsx` の場合
   - 生成されるキーワードは `['crews', 'crew', 'index', 'page']`
@@ -347,17 +326,33 @@ const betterNames = {
 ### rules
 
 ```js
+const ignorekeywords = ['views', 'parts']
+const betterNames = {
+  '\/repositories\/': {
+    operator: '-',
+    names: ['repository', 'Repository'],
+  },
+  '\/entities\/': {
+    operator: '+',
+    names: ['entity'],
+  },
+  '\/slices\/': {
+    operator: '=',
+    names: ['index'],
+  },
+}
+
 {
   rules: {
     'smarthr/redundant-name': [
       'error', // 'warn', 'off'
       {
-        type: { ignorekeywords, betterNames, suffix: ['Props', 'Type'] },
-        file: { ignorekeywords, betterNames },
-        // property: { ignorekeywords, betterNames },
-        // function: { ignorekeywords, betterNames },
-        // variable: { ignorekeywords, betterNames },
-        // class: { ignorekeywords, betterNames },
+        type: { ignorekeywords, suffix: ['Props', 'Type'] },
+        file: { ignorekeywords, betternames },
+        // property: { ignorekeywords },
+        // function: { ignorekeywords },
+        // variable: { ignorekeywords },
+        // class: { ignorekeywords },
       }
     ]
   },

--- a/README.md
+++ b/README.md
@@ -309,10 +309,10 @@ import { PrimaryButton, SecondaryButton } from 'smarthr-ui'
   - ignoreKeywords
     - ディレクトリ名から生成されるキーワードに含めたくない文字列を指定します
   - betterNames
-    - 対象の名前を修正する候補を生成します
-  - suffixGenerator:
+    - 対象の名前を修正する候補を指定します
+  - suffix:
     - type のみ指定出来ます
-    - type のsuffixを生成します
+    - type のsuffixを指定します
 
 #### 指定例
 ```
@@ -333,20 +333,6 @@ const betterNames = {
     },
   },
 }
-
-// 例: actions 以下の場合だけ 'Action' もしくは `Actions` のSuffixを許可する
-const suffixGenerator = ({ node, filename }) => {
-  let suffix = ['Props', 'Type']
-
-  if (filename.match(/\/actions\//)) {
-    suffix = [
-      isUnionType || (node.typeAnnotation.type === 'TSTypeReference' && node.id.name.match(/Actions$/))
-        ? 'Actions'
-        : 'Action',
-      ...suffix,
-    ]
-  }
-}
 ```
 
 #### ファイル例
@@ -366,7 +352,7 @@ const suffixGenerator = ({ node, filename }) => {
     'smarthr/redundant-name': [
       'error', // 'warn', 'off'
       {
-        type: { ignorekeywords, betterNames, suffixGenerator },
+        type: { ignorekeywords, betterNames, suffix: ['Props', 'Type'] },
         file: { ignorekeywords, betterNames },
         // property: { ignorekeywords, betterNames },
         // function: { ignorekeywords, betterNames },

--- a/README.md
+++ b/README.md
@@ -308,10 +308,7 @@ import { PrimaryButton, SecondaryButton } from 'smarthr-ui'
 - 以下の設定を行えます。全て省略可能です。
   - ignoreKeywords
     - ディレクトリ名から生成されるキーワードに含めたくない文字列を指定します
-  - keywordsGenerator
-    - ディレクトリ名から生成されるキーワードを元に最終的なキーワードを生成します
-    - 主に複数形のキーワードから単数形を生成するために利用します
-  - betterNamesGenerator
+  - betterNames
     - 対象の名前を修正する候補を生成します
   - suffixGenerator:
     - type のみ指定出来ます
@@ -320,38 +317,21 @@ import { PrimaryButton, SecondaryButton } from 'smarthr-ui'
 #### 指定例
 ```
 const ignorekeywords = ['views', 'parts']
-const keywordsGenerator = ({ keywords }) => (
-  keywords.reduce((prev, keyword, index) => {
-    switch (keyword) {
-      case 'repositories':
-        return [...prev, keyword, 'repository']
-    }
-
-    const replacedKeyword = keyword.replace(/(repository|s)$/, '')
-    if (keyword !== replacedKeyword) {
-      return [...prev, keyword, replacedKeyword]
-    }
-
-    return [...prev, keyword]
-  }, [])
-)
-const betterNamesGenerator = betterNamesGenerator: ({ candidates, redundantName, redundantType, filename }) => {
-  if (filename.match('/repositories/')) {
-    switch (redundantType) {
-      case 'file': 
-        return candidates.filter((c) => c !== 'repository')
-      case 'variable': 
-        return ['repository']
-    }
-  }
-
-  if (filename.match('/entities/')) {
-    if (redundantType === 'class') {
-      return ['Entity']
-    }
-  }
-
-  return candidates
+const betterNames = {
+  '\/repositories\/': {
+    file: {
+      operator: '-',
+      names: ['repository', 'Repository'],
+    },
+    variable: {
+      operator: '=',
+      names: ['repository'],
+    },
+    type: {
+      operator: '+',
+      names: ['Props'],
+    },
+  },
 }
 
 // 例: actions 以下の場合だけ 'Action' もしくは `Actions` のSuffixを許可する
@@ -386,12 +366,12 @@ const suffixGenerator = ({ node, filename }) => {
     'smarthr/redundant-name': [
       'error', // 'warn', 'off'
       {
-        type: { ignorekeywords, keywordsGenerator, betterNamesGenerator, suffixGenerator },
-        file: { ignorekeywords, keywordsGenerator, betterNamesGenerator },
-        // property: { ignorekeywords, keywordsGenerator, betterNamesGenerator },
-        // function: { ignorekeywords, keywordsGenerator, betterNamesGenerator },
-        // variable: { ignorekeywords, keywordsGenerator, betterNamesGenerator },
-        // class: { ignorekeywords, keywordsGenerator, betterNamesGenerator },
+        type: { ignorekeywords, betterNames, suffixGenerator },
+        file: { ignorekeywords, betterNames },
+        // property: { ignorekeywords, betterNames },
+        // function: { ignorekeywords, betterNames },
+        // variable: { ignorekeywords, betterNames },
+        // class: { ignorekeywords, betterNames },
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "url": "https://github.com/kufu/eslint-plugin-smarthr/issues"
   },
   "dependencies": {
+    "inflected": "^2.1.0",
     "json5": "^2.2.0"
   },
   "devDependencies": {

--- a/rules/redundant-name.js
+++ b/rules/redundant-name.js
@@ -26,9 +26,28 @@ const DEFAULT_CONFIG = {
   method: COMMON_DEFAULT_CONFIG,
 }
 
+const BETTER_NAMES_CALCULATER_PROPERTY = {
+  type: 'object',
+  properties: {
+    operator: ['-', '+', '='],
+    names:  {
+      type: 'array',
+      items: 'string',
+    },
+  },
+}
 const DEFAULT_SCHEMA_PROPERTY = {
   ignoreKeywords: { type: 'array', items: { type: 'string' } },
-  betterNames: { type: 'object' },
+  betterNames: {
+    type: 'object',
+    properties: {
+      operator: ['-', '+', '='],
+      names:  {
+        type: 'array',
+        items: 'string',
+      },
+    },
+  },
 }
 
 const SCHEMA = [
@@ -141,9 +160,7 @@ const handleReportBetterName = ({
       candidates = uniq([conciseName, ...candidates].filter((k) => !!k))
 
       if (option.betterNames) {
-        Object.entries(option.betterNames).forEach(([regex, calculator]) => {
-          const calc = calculator[key]
-
+        Object.entries(option.betterNames).forEach(([regex, calc]) => {
           if (calc && filename.match(new RegExp(regex))) {
             switch(calc.operator) {
               case '=': 

--- a/rules/redundant-name.js
+++ b/rules/redundant-name.js
@@ -37,7 +37,7 @@ const SCHEMA = [
     properties: {
       type: {
         ...DEFAULT_SCHEMA_PROPERTY,
-        suffixGenerator: { type: 'function' },
+        suffix: { type: 'array', items: { type: 'string' } },
       },
       typeProperty: DEFAULT_SCHEMA_PROPERTY,
       file: DEFAULT_SCHEMA_PROPERTY,
@@ -181,17 +181,10 @@ const generateTypeRedundant = (args) => {
   const redundantKeywords = generateRedundantKeywords({ args, key })
   const option = args.option[key]
   const defaultConfig = DEFAULT_CONFIG[key]
-  const actualArgs = {
-    ...args,
-    redundantKeywords,
-  }
 
   return (node) => {
     const typeName = node.id.name
-    const suffix = option.suffixGenerator ? option.suffixGenerator({
-      ...actualArgs,
-      node,
-    }) : defaultConfig.SUFFIX
+    const suffix = option.suffix || defaultConfig.SUFFIX
 
     let SuffixedName = typeName
     let report = null

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,6 +573,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+inflected@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/inflected/-/inflected-2.1.0.tgz#2816ac17a570bbbc8303ca05bca8bf9b3f959687"
+  integrity sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==
+
 inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"


### PR DESCRIPTION
- テスト環境を適用できるようにするため、optionでfunction を渡している箇所を調整します
  - domain判断用の関数をoptionではなく、rule内で持つように調整
  - keyword生成用の処理をoptionではなく、rule内で持つように調整
  - redundant-nameの修正例として出力される名前を関数で生成するのではなく、修正用設定を指定するように修正