### PR TITLE
chore: jsx-start-with-spread-attributes に fix optionを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,19 @@ import globalModulePart from '@/modules/views/parts'
 ## smarthr/jsx-start-with-spread-attributes
 
 - jsxを記述する際、意図しない属性の上書きを防ぐため、spread-attributesを先に指定するように強制するruleです
+- eslint を `--fix` オプション付きで実行する際、 fix option を true にすると自動修正します
 
 ### rules
 
 ```js
 {
   rules: {
-    'smarthr/jsx-start-with-spread-attributes': 'error', // 'warn', 'off'
+    'smarthr/jsx-start-with-spread-attributes': [
+      'error', // 'warn', 'off'
+      {
+        fix: false, // true
+      },
+    ]
   },
 }
 ```

--- a/rules/jsx-start-with-spread-attributes.js
+++ b/rules/jsx-start-with-spread-attributes.js
@@ -35,19 +35,20 @@ module.exports = {
 
         if (insertIndex >= 0) {
           const option = context.options[0]
+          const sourceCode = context.getSourceCode()
+          const attributeCode = sourceCode.getText(node)
 
           context.report({
             node,
             messageId: 'jsx-start-with-spread-attributes',
             data: {
-              message: `"${context.getSourceCode().getText(node)}" は意図しない上書きを防ぐため、spread attributesでない属性より先に記述してください`,
+              message: `"${attributeCode}" は意図しない上書きを防ぐため、spread attributesでない属性より先に記述してください`,
             },
             fix: option?.fix ? (fixer) => {
-              const sourceCode = context.getSourceCode()
               const elementNode = node.parent
               const sortedAttributes = [...elementNode.attributes].reduce((p, a, i) => {
                 if (insertIndex === i) {
-                  p = [sourceCode.getText(node), ...p]
+                  p = [attributeCode, ...p]
                 }
 
                 if (a !== node) {

--- a/rules/jsx-start-with-spread-attributes.js
+++ b/rules/jsx-start-with-spread-attributes.js
@@ -1,38 +1,71 @@
+const SCHEMA = [
+  {
+    type: 'object',
+    properties: {
+      fix: { type: 'boolean', default: false },
+    },
+    additionalProperties: false,
+  }
+]
+
 module.exports = {
   meta: {
     type: 'suggestion',
     messages: {
       'jsx-start-with-spread-attributes': '{{ message }}',
     },
-    schema: [],
+    fixable: 'code',
+    schema: SCHEMA,
   },
   create(context) {
     return {
       JSXSpreadAttribute: (node) => {
-        // HINT: 0: 計算中 1: 見つからなかった 2: 見つかった 
-        const hit = node.parent.attributes.reduce((h, a) => {
-          if (h === 0) {
+        // HINT: -2: 計算中 -1: 見つからなかった >= 0: 見つかった 
+        const insertIndex = node.parent.attributes.reduce((h, a, i) => {
+          if (h === -2) {
             if (a === node) {
-              return 1
+              return -1
             }
 
-            return a.type !== 'JSXSpreadAttribute' ? 2 : 0
+            return a.type !== 'JSXSpreadAttribute' ? i : h
           }
 
           return h
-        }, 0)
+        }, -2)
 
-        if (hit === 2) {
+        if (insertIndex >= 0) {
+          const option = context.options[0]
+
           context.report({
             node,
             messageId: 'jsx-start-with-spread-attributes',
             data: {
-              message: `"${context.getSourceCode().getText(node)}" は他の属性より先に記述してください`,
+              message: `"${context.getSourceCode().getText(node)}" は意図しない上書きを防ぐため、spread attributesでない属性より先に記述してください`,
             },
+            fix: option?.fix ? (fixer) => {
+              const sourceCode = context.getSourceCode()
+              const elementNode = node.parent
+              const sortedAttributes = [...elementNode.attributes].reduce((p, a, i) => {
+                if (insertIndex === i) {
+                  p = [sourceCode.getText(node), ...p]
+                }
+
+                if (a !== node) {
+                  p = [...p, sourceCode.getText(a)]
+                }
+
+                return p
+              }, [])
+
+              return fixer.replaceText(
+                elementNode,
+                `<${elementNode.name.name} ${sortedAttributes.join(' ')}${elementNode.selfClosing ? '/' : ''}>`
+              )
+            } : null
           });
         }
       },
     }
   },
 }
-module.exports.schema = []
+module.exports.schema = SCHEMA


### PR DESCRIPTION
- jsx-start-with-spread-attributes に fix option を追加
  - 意図して値を spread attributes で上書きしている可能性もあるため、 --fix での自動修正時に上書きするかどうかはユーザーが選べるようにしました