### PR TITLE
feat: add require-barrel-import rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,46 @@ import { SecondaryButton } from 'smarthr-ui'
 import useTitle from '.hooks/useTitle'
 ```
 
+## smarthr/require-barrel-import
+
+- tsconfig.json の compilerOptions.pathsに '@/*' としてroot path を指定する必要があります
+- importした対象が本来exportされているべきであるbarrel(index.tsなど)が有る場合、import pathの変更を促します
+  - 例: Page/parts/Menu/Item の import は Page/parts/Menu から行わせたい
+- ディレクトリ内のindexファイルを捜査し、対象を決定します
+
+### rules
+
+```js
+{
+  rules: {
+    'smarthr/require-barrel-import': 'error',
+  },
+}
+```
+
+### ❌ Incorrect
+
+```js
+// client/src/views/Page/parts/Menu/index.ts
+export { Menu } from './Menu'
+export { Item } from './Item'
+
+// client/src/App.tsx
+import { Item } from './Page/parts/Menu/Item'
+```
+
+### ✅ Correct
+
+
+```js
+// client/src/views/Page/parts/Menu/index.ts
+export { Menu } from './Menu'
+export { Item } from './Item'
+
+// client/src/App.tsx
+import { Item } from './Page/parts/Menu'
+```
+
 
 ## smarthr/redundant-name
 

--- a/rules/require-barrel-import.js
+++ b/rules/require-barrel-import.js
@@ -1,0 +1,125 @@
+const path = require('path')
+const fs = require('fs')
+const { replacePaths, rootPath } = require('../libs/common')
+const calculateAbsoluteImportPath = (source) => {
+  if (source[0] === '/') {
+    return source
+  }
+
+  return Object.entries(replacePaths).reduce((prev, [key, values]) => {
+    if (source === prev) {
+      return values.reduce((p, v) => {
+        if (prev === p) {
+          const regexp = new RegExp(`^${key}(.+)$`)
+
+          if (prev.match(regexp)) {
+            return p.replace(regexp, `${path.resolve(`${process.cwd()}/${v}`)}/$1`)
+          }
+        }
+
+        return p
+      }, prev)
+    }
+
+    return prev
+  }, source)
+}
+const calculateReplacedImportPath = (source) => {
+  return Object.entries(replacePaths).reduce((prev, [key, values]) => {
+    if (source === prev) {
+      return values.reduce((p, v) => {
+        if (prev === p) {
+          const regexp = new RegExp(`^${path.resolve(`${process.cwd()}/${v}`)}(.+)$`)
+
+          if (prev.match(regexp)) {
+            return p.replace(regexp, `${key}/$1`).replace(/(\/)+/g, '/')
+          }
+        }
+
+        return p
+      }, prev)
+    }
+
+    return prev
+  }, source)
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      'require-barrel-import': '{{ message }}',
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.getFilename()
+
+    // HINT: indexファイルがある == barrelであるとする
+    if (filename.match(/\/index\.(js|ts)x?$/)) {
+      return {}
+    }
+
+    const dir = (() => {
+      const d = filename.split('/')
+      d.pop()
+
+      return d.join('/')
+    })()
+
+    return {
+      ImportDeclaration: (node) => {
+        let sourceValue = node.source.value
+
+        if (sourceValue[0] === '.') {
+          sourceValue = path.resolve(`${dir}/${sourceValue}`)
+        }
+
+        sourceValue = calculateAbsoluteImportPath(sourceValue)
+
+        if (sourceValue[0] !== '/') {
+          return
+        }
+
+        const sources = sourceValue.split('/')
+        let joinedSources = sourceValue
+        let ext = undefined
+
+        while (sources.length > 0) {
+          // HINT: 以下の場合は即終了
+          // - import元以下のimportだった場合
+          // - rootまで捜索した場合
+          if (dir === joinedSources || dir === rootPath) {
+            return
+          }
+
+          ext = ['ts', 'tsx', 'js', 'jsx'].find((e) => fs.existsSync(`${sources.join('/')}/index.${e}`))
+
+          if (ext) {
+            break
+          }
+
+          sources.pop()
+          joinedSources = sources.join('/')
+        }
+
+        if (
+          joinedSources &&
+          sourceValue !== joinedSources &&
+          !dir.match(new RegExp(`^${joinedSources}/`))
+        ) {
+          const replacedSources = calculateReplacedImportPath(joinedSources)
+
+          context.report({
+            node,
+            messageId: 'require-barrel-import',
+            data: {
+              message: `${replacedSources}からimportするか、${replacedSources}/index.${ext}を削除してください`,
+            },
+          });
+        }
+      },
+    }
+  },
+}
+module.exports.schema = []


### PR DESCRIPTION
- Barrelがある（少なくともexportしておくべきindexファイルが有る）のに直接importしてしまっている場合に教えてくれるruleを作成します。