### PR TITLE
feat: リンク要素内にテキストが設定されていない場合、エラーとなるルールを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
 # eslint-plugin-smarthr
 
+## smarthr/a11y-anchor-has-text
+
+- Anchor, Link にテキスト要素が設定されていない場合など、アクセシビリティの問題が発生する可能性を防ぐルールです
+
+### rules
+
+```js
+{
+  rules: {
+    'smarthr/a11y-anchor-has-text': 'error', // 'warn', 'off'
+  },
+}
+```
+
+### ❌ Incorrect
+
+```jsx
+<XxxAnchor>
+  <Yyy />
+</XxxAnchor>
+```
+
+```jsx
+<XxxLink>
+  <Zzz />
+</XxxLink>
+```
+
+### ✅ Correct
+
+```jsx
+<XxxAnchor>
+  Hoge
+</XxxAnchor>
+```
+```jsx
+<XxxLink>
+  <YyyIcon />
+  Fuga
+</XxxLink>
+```
+```jsx
+<XxxAnchor>>
+  <YyyIcon visuallyHiddenText="hoge" />
+</XxxAnchor>
+```
+```jsx
+<XxxLink>
+  <YyyImage alt="fuga" />
+</XxxLink>
+```
+
 ## smarthr/a11y-icon-button-has-name
 
 - ボタンの中にIconのみが設置されている場合、アクセシビリティの問題が発生する可能性を防ぐルールです
@@ -39,6 +91,11 @@
 ```jsx
 <XxxButton>
   <YyyIcon visuallyHiddenText="hoge" />
+</XxxButton>
+```
+```jsx
+<XxxButton>
+  <YyyIcon alt="fuga" />
 </XxxButton>
 ```
 

--- a/rules/a11y-anchor-has-text.js
+++ b/rules/a11y-anchor-has-text.js
@@ -13,7 +13,7 @@ module.exports = {
   create(context) {
     return {
       JSXOpeningElement: (node) => {
-        if (!node.name.name || !node.name.name.match(/^(a|(.*?)Anchor|(.*?)Link)$/)) {
+        if (!node.name.name || !node.name.name.match(/^(a|(.*?)Anchor(Button)?|(.*?)Link)$/)) {
           return
         }
 

--- a/rules/a11y-anchor-has-text.js
+++ b/rules/a11y-anchor-has-text.js
@@ -23,7 +23,7 @@ module.exports = {
           }
 
           if (c.type === 'JSXElement') {
-            if (c.openingElement.attributes.some((a) => ['visuallyHiddenText', 'alt'].includes(a.name.name))) {
+            if (c.openingElement.attributes.some((a) => (['visuallyHiddenText', 'alt'].includes(a.name.name) && !!a.value.value))) {
               return true
             }
 

--- a/rules/a11y-anchor-has-text.js
+++ b/rules/a11y-anchor-has-text.js
@@ -1,0 +1,59 @@
+const filterFalsyJSXText = (cs) => cs.filter((c) => (
+  !(c.type === 'JSXText' && c.value.match(/^\s*\n+\s*$/))
+))
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      'a11y-anchor-has-text': '{{ message }}',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSXOpeningElement: (node) => {
+        if (!node.name.name || !node.name.name.match(/(Anchor|Link)$/)) {
+          return
+        }
+
+        const children = filterFalsyJSXText(node.parent.children)
+
+        if (children.length === 0) {
+          return
+        }
+
+        const recursiveSearch = (c) => {
+          if (['JSXText', 'JSXExpressionContainer'].includes(c.type)) {
+            return true
+          }
+
+          if (c.type === 'JSXElement') {
+            if (c.openingElement.attributes.some((a) => ['visuallyHiddenText', 'alt'].includes(a.name.name))) {
+              return true
+            }
+
+            if (c.children && filterFalsyJSXText(c.children).some(recursiveSearch)) {
+              return true
+            }
+          }
+
+          return false
+        }
+
+        const child = children.find(recursiveSearch)
+
+        if (!child) {
+          context.report({
+            node,
+            messageId: 'a11y-anchor-has-text',
+            data: {
+              message: 'リンク要素にはテキストを設定してください。リンク要素内にアイコン、画像を設置する場合はvisuallyHiddenText、altなどの代替テキスト用属性を指定してください',
+            },
+          });
+        }
+      },
+    }
+  },
+}
+module.exports.schema = []

--- a/rules/a11y-anchor-has-text.js
+++ b/rules/a11y-anchor-has-text.js
@@ -17,12 +17,6 @@ module.exports = {
           return
         }
 
-        const children = filterFalsyJSXText(node.parent.children)
-
-        if (children.length === 0) {
-          return
-        }
-
         const recursiveSearch = (c) => {
           if (['JSXText', 'JSXExpressionContainer'].includes(c.type)) {
             return true
@@ -41,7 +35,7 @@ module.exports = {
           return false
         }
 
-        const child = children.find(recursiveSearch)
+        const child = filterFalsyJSXText(node.parent.children).find(recursiveSearch)
 
         if (!child) {
           context.report({

--- a/rules/a11y-anchor-has-text.js
+++ b/rules/a11y-anchor-has-text.js
@@ -13,7 +13,7 @@ module.exports = {
   create(context) {
     return {
       JSXOpeningElement: (node) => {
-        if (!node.name.name || !node.name.name.match(/(Anchor|Link)$/)) {
+        if (!node.name.name || !node.name.name.match(/^(a|(.*?)Anchor|(.*?)Link)$/)) {
           return
         }
 

--- a/rules/a11y-icon-button-has-name.js
+++ b/rules/a11y-icon-button-has-name.js
@@ -31,7 +31,7 @@ module.exports = {
             targetNode = c
 
             if (!existNoIcon) {
-              existNoIcon = c.openingElement.attributes.some((a) => a.name.name === 'visuallyHiddenText')
+              existNoIcon = c.openingElement.attributes.some((a) => ['visuallyHiddenText', 'alt'].includes(a.name.name))
             }
           } else {
             existNoIcon = true
@@ -45,7 +45,7 @@ module.exports = {
             node: targetNode,
             messageId: 'a11y-icon-button-has-name',
             data: {
-              message: `Button 内に Icon のみを設置する場合、Icon に visuallyHiddenText props を指定してください`,
+              message: 'Button 内に Icon のみを設置する場合、Icon に visuallyHiddenText props、もしくは alt props を指定してください',
             },
           });
         }

--- a/test/a11y-anchor-has-text.js
+++ b/test/a11y-anchor-has-text.js
@@ -1,0 +1,84 @@
+const rule = require('../rules/a11y-anchor-has-text')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+})
+
+const defaultErrorMessage = 'リンク要素にはテキストを設定してください。リンク要素内にアイコン、画像を設置する場合はvisuallyHiddenText、altなどの代替テキスト用属性を指定してください'
+
+ruleTester.run('a11y-anchor-has-text', rule, {
+  valid: [
+    {
+      code: `<a>ほげ</a>`,
+    },
+    {
+      code: `<Link>ほげ</Link>`,
+    },
+    {
+      code: `<HogeLink>ほげ</HogeLink>`,
+    },
+    {
+      code: `<Anchor>ほげ</Anchor>`,
+    },
+    {
+      code: `<FugaAnchor>ほげ</FugaAnchor>`,
+    },
+    {
+      code: `<AnchorButton>ほげ</AnchorButton>`,
+    },
+    {
+      code: `<HogaAnchorButton>ほげ</HogaAnchorButton>`,
+    },
+    {
+      code: `<a><span>ほげ</span></a>`,
+    },
+    {
+      code: `<a><AnyComponent>ほげ</AnyComponent></a>`,
+    },
+    {
+      code: `<a><img src="hoge.jpg" alt="ほげ" /></a>`,
+    },
+    {
+      code: `<a><Icon visuallyHiddenText="ほげ" /></a>`,
+    },
+    {
+      code: `<a><AnyComponent><Icon visuallyHiddenText="ほげ" /></AnyComponent></a>`,
+    },
+    {
+      code: `<a>{any}</a>`,
+    },
+    {
+      code: `<a><span>{any}</span></a>`,
+    },
+  ],
+  invalid: [
+    {
+      code: `<a><img src="hoge.jpg" /></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+    {
+      code: `<a><Any /></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+    {
+      code: `<a><span><Any /></span></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+    {
+      code: `<a><img src="hoge.jpg" alt="" /></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+    {
+      code: `<a><AnyComponent><Icon visuallyHiddenText="" /></AnyComponent></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+  ]
+})


### PR DESCRIPTION
- a、 `AnchorButton` などのchildren内にテキストとなるものがない場合、エラーとなるルールを追加します
- 以前作成済みの `Button 内にアイコンのみで代替テキストがない場合エラーとする` ルールにalt指定されていればOKとする修正を加えます