### PR TITLE
fix: redundant-nameが単数形のファイル名を対象にした場合、修整例が "s" のみになってしまう場合が有るバグを修正する

### DIFF
--- a/rules/redundant-name.js
+++ b/rules/redundant-name.js
@@ -91,9 +91,11 @@ const generateRedundantKeywords = ({ args, key, terminalImportName }) => {
       return prev
     }
 
-    const singularized = Inflector.singularize(keyword)
-
-    return singularized === keyword ? [...prev, keyword] : [...prev, keyword, singularized]
+    return [...prev, ...uniq([
+      Inflector.pluralize(keyword),
+      keyword,
+      Inflector.singularize(keyword),
+    ])]
   }, [])
 }
 const handleReportBetterName = ({


### PR DESCRIPTION
- パス、ファイル名をベースに冗長な変数名などの修正例を提示するredundant-nameのバグを修正したい
- パス中に単数形の名称が存在する場合、かつ対象となる名称が `xxxs`のように複数形の場合、`s` だけになってしまう場合があったため修正したい