### PR TITLE
chore: update README

### DIFF
--- a/rules/format-import-path/README.md
+++ b/rules/format-import-path/README.md
@@ -7,7 +7,7 @@
 
 ## config
 
-- tsconfig.json の compilerOptions.pathsに '@/*' としてroot path を指定する必要があります
+- tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
 - ドメインを識別するために以下の設定を記述する必要があります
   - globalModuleDir
     - 全体で利用するファイルを収めているディレクトリを相対パスで指定します

--- a/rules/no-import-other-domain/README.md
+++ b/rules/no-import-other-domain/README.md
@@ -6,7 +6,7 @@
 
 ## config
 
-- tsconfig.json の compilerOptions.pathsに '@/*' としてroot path を指定する必要があります
+- tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
 - ドメインを識別するために以下の設定を記述する必要があります
   - globalModuleDir
     - 全体で利用するファイルを収めているディレクトリを相対パスで指定します

--- a/rules/redundant-name/README.md
+++ b/rules/redundant-name/README.md
@@ -5,7 +5,7 @@
 
 ## config
 
-- tsconfig.json の compilerOptions.pathsに '@/*' としてroot path を指定する必要があります
+- tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
 - 以下の設定を行えます。全て省略可能です。
   - ignoreKeywords
     - ディレクトリ名から生成されるキーワードに含めたくない文字列を指定します

--- a/rules/redundant-name/index.js
+++ b/rules/redundant-name/index.js
@@ -406,7 +406,7 @@ module.exports = {
   },
   create(context) {
     if (!rootPath) {
-      throw new Error('tsconfig.json の compilerOptions.paths に `"@/*": ["any_path/*"]` 形式でフロントエンドのroot dir を指定してください')
+      throw new Error('tsconfig.json の compilerOptions.paths に `@/*`、もしくは `~/*` 形式でフロントエンドのroot dir を指定してください(例: `"@/*": ["./any_path/*"]`)')
     }
 
     let rules = {}

--- a/rules/require-barrel-import/README.md
+++ b/rules/require-barrel-import/README.md
@@ -1,6 +1,6 @@
 # smarthr/require-barrel-import
 
-- tsconfig.json の compilerOptions.pathsに '@/*' としてroot path を指定する必要があります
+- tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
 - importした対象が本来exportされているべきであるbarrel(index.tsなど)が有る場合、import pathの変更を促します
   - 例: Page/parts/Menu/Item の import は Page/parts/Menu から行わせたい
 - ディレクトリ内のindexファイルを捜査し、対象を決定します


### PR DESCRIPTION
- root取得用の処理を調整した結果がREADMEに反映しました
   - tsconfig.jsonの compilerOptions.paths に設定するrootパスを `@/*` だけではなく `~/*` でも登録可能にしました