### PR TITLE
fix: 画像系コンポーネントが代替テキスト属性を持つかチェックする際にエラーになるパターンを修正

### DIFF
--- a/rules/a11y-clickable-element-has-text/index.js
+++ b/rules/a11y-clickable-element-has-text/index.js
@@ -36,17 +36,29 @@ module.exports = {
           return
         }
 
-        const recursiveSearch = (c) => (
-          ['JSXText', 'JSXExpressionContainer'].includes(c.type) ||
-          (
-            c.type === 'JSXElement' && (
-              // HINT: SmartHRLogo コンポーネントは内部でaltを持っているため対象外にする
-              c.openingElement.name.name.match(/SmartHRLogo$/) ||
-              c.openingElement.attributes.some((a) => (['visuallyHiddenText', 'alt'].includes(a.name.name) && !!a.value.value)) ||
-              (c.children && filterFalsyJSXText(c.children).some(recursiveSearch))
-            )
-          )
-        ) 
+        const recursiveSearch = (c) => {
+          if (['JSXText', 'JSXExpressionContainer'].includes(c.type)) {
+            return true
+          }
+
+          if (c.type === 'JSXElement') {
+            if (c.openingElement.attributes.some((a) =>  {
+              if (!['visuallyHiddenText', 'alt'].includes(a.name.name)) {
+                return false
+              }
+
+              return (!!a.value.value || a.value.type === 'JSXExpressionContainer')
+            })) {
+              return true
+            }
+
+            if (c.children && filterFalsyJSXText(c.children).some(recursiveSearch)) {
+              return true
+            }
+          }
+
+          return false
+        }
 
         const child = filterFalsyJSXText(parentNode.children).find(recursiveSearch)
 

--- a/rules/a11y-clickable-element-has-text/index.js
+++ b/rules/a11y-clickable-element-has-text/index.js
@@ -42,6 +42,11 @@ module.exports = {
           }
 
           if (c.type === 'JSXElement') {
+            // // HINT: SmartHRLogo コンポーネントは内部でaltを持っているため対象外にする
+            if (c.openingElement.name.name.match(/SmartHRLogo$/)) {
+              return true
+            }
+            
             if (c.openingElement.attributes.some((a) =>  {
               if (!['visuallyHiddenText', 'alt'].includes(a.name.name)) {
                 return false

--- a/rules/a11y-image-has-alt-attribute/index.js
+++ b/rules/a11y-image-has-alt-attribute/index.js
@@ -21,7 +21,7 @@ module.exports = {
       ...generateTagFormatter({ context, EXPECTED_NAMES }),
       JSXOpeningElement: (node) => {
         if ((node.name.name || '').match(/(img|image)$/i)) { // HINT: Iconは別途テキストが存在する場合が多いためチェックの対象外とする
-          const alt = node.attributes.find((a) => a.name.name === 'alt')
+          const alt = node.attributes.find((a) => a.name?.name === 'alt')
 
           let message = ''
 


### PR DESCRIPTION
画像のaltチェック似バグが見つかったので修正します

- 特定の記法の際にエラーになってしまうバグを修正
- 特定の状況化でalt属性が未指定扱いになってしまうバグを修正