### PR TITLE
feat: add a11y-prohibit-input-placeholder rule.

### DIFF
--- a/rules/a11y-prohibit-input-placeholder/README.md
+++ b/rules/a11y-prohibit-input-placeholder/README.md
@@ -1,0 +1,36 @@
+# smarthr/a11y-prohibit-input-placeholder
+
+- input や textarea などの入力要素に対して placeholder を設定することを禁止するルールです
+  - placeholder は入力要素に値を設定すると閲覧が不可能になるため、アクセシビリティの観点からは基本的に非推奨です
+- Tooltip や 別途ヒント用の要素を作成し、そちらを表示することで基本的にユーザーが閲覧する必要のあるタイミングで常に見ることができるようにしてください
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/a11y-prohibit-input-placeholder': 'error', // 'warn', 'off'
+  },
+}
+```
+
+## ❌ Incorrect
+
+```jsx
+<Input placeholder="hoge" />
+```
+```jsx
+<CustomTextarea placeholder="hoge" />
+```
+
+## ✅ Correct
+
+```jsx
+<CustomInput tooltip="hoge" />
+```
+```jsx
+<Wrapper>
+  <Textarea />
+  <Hint>hoge</Hint>
+</Wrapper>
+```

--- a/rules/a11y-prohibit-input-placeholder/index.js
+++ b/rules/a11y-prohibit-input-placeholder/index.js
@@ -1,0 +1,46 @@
+const { generateTagFormatter } = require('../../libs/format_styled_components')
+
+const EXPECTED_NAMES = {
+  '(i|I)nput$': 'Input$',
+  '(t|T)extarea$': 'Textarea$',
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      'format-styled-components': '{{ message }}',
+      'a11y-prohibit-input-placeholder': '{{ message }}',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ...generateTagFormatter({ context, EXPECTED_NAMES }),
+      JSXOpeningElement: (node) => {
+        if (!node.name.name) {
+          return
+        }
+
+        const match = node.name.name.match(/((i|I)nput|(t|T)extarea)$/)
+
+        if (!match) {
+          return
+        }
+
+        const placeholder = node.attributes.find((a) => a.name?.name === 'placeholder')
+
+        if (placeholder) {
+          context.report({
+              node: placeholder,
+              messageId: 'a11y-prohibit-input-placeholder',
+              data: {
+                message: 'input, textarea要素のplaceholder属性は設定せず、smarthr-ui/Tooltip や別途ヒント用要素の利用を検討してください (例: `<><Input /><Hint>ヒント</Hint></>`, `<Tooltip message="ヒント"><Textarea/></Tooltip>`)',
+              },
+            })
+        }
+      },
+    }
+  },
+}
+module.exports.schema = []

--- a/test/a11y-prohhibit-input-placeholder.js
+++ b/test/a11y-prohhibit-input-placeholder.js
@@ -1,0 +1,41 @@
+const rule = require('../rules/a11y-prohibit-input-placeholder')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('a11y-prohibit-input-placeholder', rule, {
+  valid: [
+    { code: `import styled from 'styled-components'` },
+    { code: `import styled, { css } from 'styled-components'` },
+    { code: `import { css } from 'styled-components'` },
+    { code: 'const HogeInput = styled.input``' },
+    { code: 'const HogeTextarea = styled.textarea``' },
+    { code: 'const HogeInput = styled(Input)``' },
+    { code: 'const HogeInput = styled(StyledInput)``' },
+    { code: 'const HogeTextarea = styled(Textarea)``' },
+    { code: `<input />` },
+    { code: `<textarea />` },
+    { code: `<StyledInput />` },
+    { code: `<HogeTextarea />` },
+  ],
+  invalid: [
+    { code: `import hoge from 'styled-components'`, errors: [ { message: "styled-components をimportする際は、名称が`styled` となるようにしてください。例: `import styled from 'styled-components'`" } ] },
+    { code: 'const Hoge = styled.input``', errors: [ { message: `Hogeを正規表現 "/Input$/" がmatchする名称に変更してください` } ] },
+    { code: 'const Hoge = styled(StyledInput)``', errors: [ { message: `Hogeを正規表現 "/Input$/" がmatchする名称に変更してください` } ] },
+    { code: 'const Hoge = styled.textarea``', errors: [ { message: `Hogeを正規表現 "/Textarea$/" がmatchする名称に変更してください` } ] },
+    { code: 'const Hoge = styled(StyledTextarea)``', errors: [ { message: `Hogeを正規表現 "/Textarea$/" がmatchする名称に変更してください` } ] },
+    { code: `<input placeholder />`, errors: [ { message: 'input, textarea要素のplaceholder属性は設定せず、smarthr-ui/Tooltip や別途ヒント用要素の利用を検討してください (例: `<><Input /><Hint>ヒント</Hint></>`, `<Tooltip message="ヒント"><Textarea/></Tooltip>`)' } ] },
+    { code: `<textarea placeholder="hoge" />`, errors: [ { message: 'input, textarea要素のplaceholder属性は設定せず、smarthr-ui/Tooltip や別途ヒント用要素の利用を検討してください (例: `<><Input /><Hint>ヒント</Hint></>`, `<Tooltip message="ヒント"><Textarea/></Tooltip>`)' } ] },
+    { code: `<StyledInput placeholder={any} />`, errors: [ { message: 'input, textarea要素のplaceholder属性は設定せず、smarthr-ui/Tooltip や別途ヒント用要素の利用を検討してください (例: `<><Input /><Hint>ヒント</Hint></>`, `<Tooltip message="ヒント"><Textarea/></Tooltip>`)' } ] },
+    { code: `<HogeTextarea placeholder="any" />`, errors: [ { message: 'input, textarea要素のplaceholder属性は設定せず、smarthr-ui/Tooltip や別途ヒント用要素の利用を検討してください (例: `<><Input /><Hint>ヒント</Hint></>`, `<Tooltip message="ヒント"><Textarea/></Tooltip>`)' } ] },
+  ]
+})


### PR DESCRIPTION
- input, textarea でplaceholder属性をヒント用要素、tooltipなどに変更することを促すルールを作成しました