### PR TITLE
fix: domain系ルールのチェック対象ファイルのdirを取得するロジックから正規表現を取り除く

### DIFF
--- a/libs/common_domain.js
+++ b/libs/common_domain.js
@@ -14,7 +14,7 @@ const calculateDomainContext = (context) => {
   }
 
   const parentDir = (() => {
-    const dir = context.getFilename().match(/^(.+?)\..+?$/)[1].split('/')
+    const dir = context.getFilename().split('/')
     dir.pop()
     return dir.join('/')
   })()


### PR DESCRIPTION
- 正規表現でファイルパスからディレクトリまでのパスを生成するロジックが存在していたが、そもそも正規表現が不要だった
- ディレクトリ名に `.` が含まれている場合、バグるので調整する