### PR TITLE
fix: a11y-clickable-element-has-textのバグを修正する

### DIFF
--- a/rules/a11y-clickable-element-has-text/README.md
+++ b/rules/a11y-clickable-element-has-text/README.md
@@ -7,7 +7,12 @@
 ```js
 {
   rules: {
-    'smarthr/a11y-clickable-element-has-text': 'error', // 'warn', 'off'
+    'smarthr/a11y-clickable-element-has-text': [
+      'error', // 'warn', 'off'
+      // {
+      //   componentsWithText: ['AnyComponentName'],
+      // },
+    ]
   },
 }
 ```
@@ -58,4 +63,21 @@
 
 ```jsx
 <YyyAnchoor />
+```
+
+```jsx
+/*
+rules: {
+  'smarthr/a11y-clickable-element-has-text': [
+    'error',
+    {
+      componentsWithText: ['AnyComponent'],
+    },
+  ]
+},
+*/
+
+<XxxButton>
+  <AnyComponent />
+</XxxButton>
 ```

--- a/rules/a11y-clickable-element-has-text/index.js
+++ b/rules/a11y-clickable-element-has-text/index.js
@@ -76,7 +76,7 @@ module.exports = {
             let existRole = false
             let existAriaLabel = false
             const result = c.openingElement.attributes.reduce((prev, a) =>  {
-              existRole = existRole || a.name.name === 'role'
+              existRole = existRole || (a.name.name === 'role' && a.value.value === 'img')
               existAriaLabel = existAriaLabel || a.name.name === 'aria-label'
 
               if (prev) {

--- a/rules/a11y-clickable-element-has-text/index.js
+++ b/rules/a11y-clickable-element-has-text/index.js
@@ -1,5 +1,15 @@
 const { generateTagFormatter } = require('../../libs/format_styled_components')
 
+const SCHEMA = [
+  {
+    type: 'object',
+    properties: {
+      componentsWithText: { type: 'array', items: { type: 'string' }, default: [] },
+    },
+    additionalProperties: false,
+  }
+]
+
 const EXPECTED_NAMES = {
   'SmartHRLogo$': 'SmartHRLogo$',
   '(b|B)utton$': 'Button$',
@@ -19,9 +29,12 @@ module.exports = {
       'format-styled-components': '{{ message }}',
       'a11y-clickable-element-has-text': '{{ message }}',
     },
-    schema: [],
+    schema: SCHEMA,
   },
   create(context) {
+    const option = context.options[0] || {}
+    const componentsWithText = option.componentsWithText || []
+
     return {
       ...generateTagFormatter({ context, EXPECTED_NAMES }),
       JSXElement: (parentNode) => {
@@ -41,19 +54,43 @@ module.exports = {
             return true
           }
 
+          if (c.type === 'JSXFragment') {
+            if (c.children && filterFalsyJSXText(c.children).some(recursiveSearch)) {
+              return true
+            }
+
+            return false
+          }
+
           if (c.type === 'JSXElement') {
             // // HINT: SmartHRLogo コンポーネントは内部でaltを持っているため対象外にする
             if (c.openingElement.name.name.match(/SmartHRLogo$/)) {
               return true
             }
-            
-            if (c.openingElement.attributes.some((a) =>  {
-              if (!['visuallyHiddenText', 'alt'].includes(a.name.name)) {
-                return false
+
+            if (componentsWithText.includes(c.openingElement.name.name)) {
+              return true
+            }
+
+            // HINT: role & aria-label を同時に設定されている場合は許可
+            let existRole = false
+            let existAriaLabel = false
+            const result = c.openingElement.attributes.reduce((prev, a) =>  {
+              existRole = existRole || a.name.name === 'role'
+              existAriaLabel = existAriaLabel || a.name.name === 'aria-label'
+
+              if (prev) {
+                return prev
               }
 
-              return (!!a.value.value || a.value.type === 'JSXExpressionContainer')
-            })) {
+              if (!['visuallyHiddenText', 'alt'].includes(a.name.name)) {
+                return prev
+              }
+
+              return (!!a.value.value || a.value.type === 'JSXExpressionContainer') ? a : prev
+            }, null)
+            
+            if (result || (existRole && existAriaLabel)) {
               return true
             }
 
@@ -80,4 +117,4 @@ module.exports = {
     }
   },
 }
-module.exports.schema = []
+module.exports.schema = SCHEMA

--- a/test/a11y-clickable-element-has-text.js
+++ b/test/a11y-clickable-element-has-text.js
@@ -163,5 +163,16 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
       code: `<button><SmartHRLogoSuffix /></button>`,
       errors: [{ message: defaultErrorMessage }]
     },
+    {
+      code: `<a><div role="article" aria-label="hoge" /></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+    {
+      code: `<a><AnyComponent /></a>`,
+      options: [{
+        componentsWithText: ['HogeComponent']
+      }],
+      errors: [{ message: defaultErrorMessage }]
+    },
   ]
 })

--- a/test/a11y-clickable-element-has-text.js
+++ b/test/a11y-clickable-element-has-text.js
@@ -96,6 +96,18 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
     {
       code: `<a><PrefixSmartHRLogo /></a>`,
     },
+    {
+      code: `<a><>ほげ</></a>`,
+    },
+    {
+      code: `<a><svg role="img" aria-label="hoge" /></a>`,
+    },
+    {
+      code: `<a><AnyComponent /></a>`,
+      options: [{
+        componentsWithText: ['AnyComponent']
+      }],
+    },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: "styled-components をimportする際は、名称が`styled` となるようにしてください。例: `import styled from 'styled-components'`" } ] },


### PR DESCRIPTION
- ReactFragmentがclickable要素の中に存在すると、ソレ以下の要素のチェックがスキップされてしまうバグを修正
- `role` と `aria-label` が同時に指定された要素がclickable要素以下に存在する場合はテキストありと判定するように修正
- テキストを持つコンポーネントを設定で指定可能にした