### PR TITLE
fix: a11y-image-has-alt-attribute が svg > image を誤検知してしまうバグを修正する

### DIFF
--- a/rules/a11y-image-has-alt-attribute/index.js
+++ b/rules/a11y-image-has-alt-attribute/index.js
@@ -7,6 +7,21 @@ const EXPECTED_NAMES = {
   '^(img|svg)$': '(Img|Image|Icon)$',
 }
 
+const isWithinSvgJsxElement = (node) => {
+  if (
+    node.type === 'JSXElement' && 
+    node.openingElement.name?.name === 'svg'
+  ) {
+    return true
+  }
+
+  if (!node.parent) {
+    return false
+  }
+
+  return isWithinSvgJsxElement(node.parent)
+}
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -20,13 +35,16 @@ module.exports = {
     return {
       ...generateTagFormatter({ context, EXPECTED_NAMES }),
       JSXOpeningElement: (node) => {
-        if ((node.name.name || '').match(/(img|image)$/i)) { // HINT: Iconは別途テキストが存在する場合が多いためチェックの対象外とする
+        const matcher = (node.name.name || '').match(/(img|image)$/i) // HINT: Iconは別途テキストが存在する場合が多いためチェックの対象外とする
+        if (matcher) { 
           const alt = node.attributes.find((a) => a.name?.name === 'alt')
 
           let message = ''
 
           if (!alt) {
-            message = '画像にはalt属性を指定してください。SVG component の場合、altを属性として受け取れるようにした上で `<svg role="img" aria-label={alt}>` のように指定してください。画像ではない場合、img or image を末尾に持たない名称に変更してください。'
+            if (matcher.input !== 'image' || !isWithinSvgJsxElement(node.parent)) {
+              message = '画像にはalt属性を指定してください。SVG component の場合、altを属性として受け取れるようにした上で `<svg role="img" aria-label={alt}>` のように指定してください。画像ではない場合、img or image を末尾に持たない名称に変更してください。'
+            }
           } else if (alt.value.value === '') {
             message = '画像の情報をテキストにした代替テキスト（`alt`）を設定してください。装飾目的の画像など、alt属性に指定すべき文字がない場合は背景画像にすることを検討してください。'
           }

--- a/test/a11y-image-has-alt-attribute.js
+++ b/test/a11y-image-has-alt-attribute.js
@@ -30,6 +30,7 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: '<HogeImg alt="hoge" />' },
     { code: '<HogeImage alt="hoge" />' },
     { code: '<HogeIcon />' },
+    { code: '<svg><image /></svg>' },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: "styled-components をimportする際は、名称が`styled` となるようにしてください。例: `import styled from 'styled-components'`" } ] },
@@ -40,5 +41,6 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: 'const Hoge = styled(Image)``', errors: [ { message: `Hogeを正規表現 "/Image$/" がmatchする名称に変更してください` } ] },
     { code: '<img />', errors: [ { message: '画像にはalt属性を指定してください。SVG component の場合、altを属性として受け取れるようにした上で `<svg role="img" aria-label={alt}>` のように指定してください。画像ではない場合、img or image を末尾に持たない名称に変更してください。' } ] },
     { code: '<HogeImage alt="" />', errors: [ { message: '画像の情報をテキストにした代替テキスト（`alt`）を設定してください。装飾目的の画像など、alt属性に指定すべき文字がない場合は背景画像にすることを検討してください。' } ] },
+    { code: '<hoge><image /></hoge>', errors: [ { message: '画像にはalt属性を指定してください。SVG component の場合、altを属性として受け取れるようにした上で `<svg role="img" aria-label={alt}>` のように指定してください。画像ではない場合、img or image を末尾に持たない名称に変更してください。' } ] },
   ]
 })


### PR DESCRIPTION
- svgタグ内のimageタグはalt属性を持たず、代替テキストの設定も不要のため、誤検知しないように修正したい