### PR TITLE
fix: redundant-nameのarrowedNameなどで利用するファイルパスが削られすぎていたため、指定が行いにくい問題を修正する

### DIFF
--- a/rules/redundant-name/index.js
+++ b/rules/redundant-name/index.js
@@ -421,7 +421,7 @@ module.exports = {
         const keywords = keywordMatcher[1].split('/')
         keywords[keywords.length - 1] = keywords[keywords.length - 1].split('.')[0]
 
-        filename = keywords.join('/')
+        filename = `${rootPath}/${keywords.join('/')}`
 
         if (keywords[keywords.length - 1] === 'index') {
           keywords.pop()


### PR DESCRIPTION
- いままでは `/any/path/xxx/yyy` だったものが `xxx/yyy` となってしまっていた
- v0.2.10 と同じフォーマットになるように修正する