### PR TITLE
feat: ignores option for no-import-other-domain and require-barrel-import

### DIFF
--- a/rules/no-import-other-domain/README.md
+++ b/rules/no-import-other-domain/README.md
@@ -56,6 +56,7 @@ const DOMAIN_RULE_ARGS = {
       'error', // 'warn', 'off'
       {
         ...DOMAIN_RULE_ARGS,
+        // ignores: ['\\/test\\/'], // 除外したいファイルの正規表現
         // analyticsMode: 'all', // 'same-domain', 'another-domain'
       }
     ]

--- a/rules/no-import-other-domain/README.md
+++ b/rules/no-import-other-domain/README.md
@@ -57,6 +57,12 @@ const DOMAIN_RULE_ARGS = {
       {
         ...DOMAIN_RULE_ARGS,
         // ignores: ['\\/test\\/'], // 除外したいファイルの正規表現
+        // allowedImports: {
+        //   '/any/path/': { // 正規表現でチェックするファイルを指定
+        //     // import制御するファイル (相対パスを指定する場合、.eslintrc.js を基準とする)
+        //     '@/hoge/fuga': true // ['abc', 'def'] と指定すると個別に指定
+        //   }
+        // },
         // analyticsMode: 'all', // 'same-domain', 'another-domain'
       }
     ]

--- a/rules/no-import-other-domain/index.js
+++ b/rules/no-import-other-domain/index.js
@@ -8,6 +8,7 @@ const SCHEMA = [
     type: 'object',
     properties: {
       ...BASE_SCHEMA_PROPERTIES,
+      ignores: { type: 'array', items: { type: 'string' }, default: [] },
       analyticsMode: { type: 'string', default: 'none' }, // 'none' | 'all' | 'same-domain' | 'another-domain'
     },
     additionalProperties: false,
@@ -27,7 +28,7 @@ module.exports = {
     const calcContext = calculateDomainContext(context)
 
     // 対象外ファイル
-    if (!calcContext.isTarget) {
+    if (!calcContext.isTarget || (calcContext.option.ignores || []).some((i) => !!calcContext.filename.match(new RegExp(i)))) {
       return {}
     }
 
@@ -65,7 +66,7 @@ module.exports = {
               message: `別ドメインから ${importPath} がimportされています。`,
             },
           })
-        } 
+        }
       },
     }
   },

--- a/rules/require-barrel-import/README.md
+++ b/rules/require-barrel-import/README.md
@@ -13,6 +13,12 @@
     'smarthr/require-barrel-import': [
       'error',
       // ignores: ['\\/test\\/'], // 除外したいファイルの正規表現
+      // allowedImports: {
+      //   '/any/path/': { // 正規表現でチェックするファイルを指定
+      //     // import制御するファイル (相対パスを指定する場合、.eslintrc.js を基準とする)
+      //     '@/hoge/fuga': true // ['abc', 'def'] と指定すると個別に指定
+      //   }
+      // },
     ],
   },
 }

--- a/rules/require-barrel-import/README.md
+++ b/rules/require-barrel-import/README.md
@@ -10,7 +10,10 @@
 ```js
 {
   rules: {
-    'smarthr/require-barrel-import': 'error',
+    'smarthr/require-barrel-import': [
+      'error',
+      // ignores: ['\\/test\\/'], // 除外したいファイルの正規表現
+    ],
   },
 }
 ```

--- a/rules/require-barrel-import/index.js
+++ b/rules/require-barrel-import/index.js
@@ -44,6 +44,15 @@ const calculateReplacedImportPath = (source) => {
   }, source)
 }
 const TARGET_EXTS = ['ts', 'tsx', 'js', 'jsx']
+const SCHEMA = [
+  {
+    type: 'object',
+    properties: {
+      ignores: { type: 'array', items: { type: 'string' }, default: [] },
+    },
+    additionalProperties: false,
+  }
+]
 
 module.exports = {
   meta: {
@@ -51,10 +60,15 @@ module.exports = {
     messages: {
       'require-barrel-import': '{{ message }}',
     },
-    schema: [],
+    schema: SCHEMA,
   },
   create(context) {
+    const option = context.options[0] || {}
     const filename = context.getFilename()
+
+    if ((option.ignores || []).some((i) => !!filename.match(new RegExp(i)))) {
+      return {}
+    }
 
     const dir = (() => {
       const d = filename.split('/')
@@ -119,4 +133,4 @@ module.exports = {
     }
   },
 }
-module.exports.schema = []
+module.exports.schema = SCHEMA


### PR DESCRIPTION
- ignoresオプションを追加します
  - ignore commentに頼らなくて良くなるため、コードをクリーンに保ちたい場合などに利用できます
- ignoresオプションより詳細にimportを制御出来るよう、arrowImportsオプションを追加します


```
       allowedImports: {
          '/test/msw/handlers': { // ファイルの正規表現
            // import制御するファイル(相対パスを指定する場合は.eslintrc.jsからの相対パス)
            '@/redux/pages/admin/crewCustomFieldTemplateGroups/index/repositories/mock': ['mocks', 'getExpect200'], // valueは true, false, string[] で string[] を指定すると、個別にimportを許可できる
          },
        },
```