### PR TITLE
feat: add prohibit-path-within-template-literal rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [prohibit-export-array-type](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/prohibit-export-array-type)
 - [prohibit-file-name](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/prohibit-file-name)
 - [prohibit-import](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/prohibit-import)
+- [prohibit-path-within-template-literal](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/prohibit-path-within-template-literal)
 - [redundant-name](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/redundant-name)
 - [require-barrel-import](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/require-barrel-import)
 - [require-declaration](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/require-declaration)

--- a/rules/prohibit-path-within-template-literal/README.md
+++ b/rules/prohibit-path-within-template-literal/README.md
@@ -1,0 +1,42 @@
+# smarthr/prohibit-path-within-template-literal
+
+- URIを管理するオブジェクト(path, localPath, GlobalPath, PATH, etc...)をtemplate-literalで囲むことを禁止するルールです
+- query-stringの生成やパスの一部などをtemplate-literalで結合することは責務を拡散させることになります
+- それらの責務を指定したオブジェクトに集中させたい場合などに利用出来ます
+  - 例
+    - NG: `\`${path.xxx}?${queryString}\``
+      - pathオブジェクト外でqueryStringが生成されてしまっており、どのようなqueryStringが設定される可能性があるか？という情報が拡散してしまう
+    - OK: `path.xxx({ xxxx: 'yyyyy' })`
+      - path内でqueryStringを生成するため、URL生成の情報が集約される
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/prohibit-path-within-template-literal': [
+      'error', // 'warn', 'off'
+      // {
+      //   pathRegex: '((p|P)ath|PATH)$', // URIを管理するオブジェクトの名称を判定する正規表現
+      // },
+    ]
+  },
+}
+```
+
+## ❌ Incorrect
+
+```jsx
+\`${path.any.hoge}\?${queryString}`
+```
+```jsx
+\`${path.any.hoge(ANY)}\${HOGE}`
+```
+```jsx
+\`${path.any.fuga}\`
+```
+
+## ✅ Correct
+```jsx
+path.any.hoge(queryString)
+```

--- a/rules/prohibit-path-within-template-literal/index.js
+++ b/rules/prohibit-path-within-template-literal/index.js
@@ -1,0 +1,60 @@
+const recursiveFetchName = (obj, chained = '') => {
+  const o = obj.callee || obj
+  const name = o.name || o.property.name || ''
+  const nextChained = chained ? `${name}.${chained}` : name
+
+  if (o.property && o.object) {
+    return recursiveFetchName(o.object, nextChained)
+  }
+
+  return [name, nextChained]
+}
+
+const recursiveFetchRootNameIsPath = (obj, regex) => {
+  const [name, chained] = recursiveFetchName(obj, '')
+
+  return name.match(regex) ? chained : null
+}
+
+const SCHEMA = [
+  {
+    type: 'object',
+    properties: {
+      pathRegex: { type: 'string', default: '((p|P)ath|PATH)$' },
+    },
+    additionalProperties: false,
+  },
+]
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      'prohibit-path-within-template-literal': '{{ message }}',
+    },
+    schema: SCHEMA,
+  },
+  create(context) {
+    const option = context.options[0]
+    const nameRegex = new RegExp(option?.pathRegex || SCHEMA[0].properties.pathRegex.default)
+
+    return {
+      TemplateLiteral: (node) => {
+        node.expressions.forEach((exp) => {
+          const name = recursiveFetchRootNameIsPath(exp, nameRegex)
+
+          if (name) {
+            context.report({
+              node: exp,
+              messageId: 'prohibit-path-within-template-literal',
+              data: {
+                message: `${name}は \`\` で囲まないでください。queryStringを結合するなどのURL生成は ${name} 内で行います。 (例: ${name}({ query: { hoge: 'abc' } })`,
+              },
+            });
+          }
+        })
+      },
+    }
+  },
+}
+module.exports.schema = SCHEMA

--- a/test/prohibit-path-within-template-literal.js
+++ b/test/prohibit-path-within-template-literal.js
@@ -1,0 +1,30 @@
+const rule = require('../rules/prohibit-path-within-template-literal')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 2015
+  },
+})
+
+ruleTester.run('prohibit-path-within-template-literal', rule, {
+  valid: [
+    { code: 'path.hoge', },
+    { code: 'path.fuga()', },
+    { code: 'localPath.any.aaa("hoge")', },
+    { code: 'PATH.some({ x })', },
+    { code: 'hoge.some({ x })', options: [{ pathRegex: '^hoge$' }] },
+  ],
+  invalid: [
+    {
+      code: '`${path.hoge}`',
+      errors: [{ message: 'path.hogeは `` で囲まないでください。queryStringを結合するなどのURL生成は path.hoge 内で行います。 (例: path.hoge({ query: { hoge: \'abc\' } })' }]
+    },
+    {
+      code: '`${ABC.hoge()}${hogehoge}`',
+      options: [{ pathRegex: '^ABC$' }],
+      errors: [{ message: 'ABC.hogeは `` で囲まないでください。queryStringを結合するなどのURL生成は ABC.hoge 内で行います。 (例: ABC.hoge({ query: { hoge: \'abc\' } })' }]
+    },
+  ]
+})


### PR DESCRIPTION
- URIを管理するオブジェクトを template-literal で囲むことを禁止するルールを追加します
- このルールを有効にすることにより、以下のメリットがあります
  - queryStringなどのURIの一部の生成ロジックが対象オブジェクトに集約するため、責務が分散せず、対象オブジェクトを見れば生成されるURLのパターンが把握しきれるようになります