### PR TITLE
fix: prohibit-path-within-template-literalのpathオブジェクト名の解析の際、エラーになるパターンがあったため修正する

### DIFF
--- a/rules/prohibit-path-within-template-literal/index.js
+++ b/rules/prohibit-path-within-template-literal/index.js
@@ -1,6 +1,6 @@
 const recursiveFetchName = (obj, chained = '') => {
   const o = obj.callee || obj
-  const name = o.name || o.property.name || ''
+  const name = o?.name || o?.property?.name || ''
   const nextChained = chained ? `${name}.${chained}` : name
 
   if (o.property && o.object) {


### PR DESCRIPTION
- `hogehoge${Obj}` のようにプロパティ参照をしないパターンの場合にエラーになってしまう事があったため修正します