### PR TITLE
fix: ディレクトリの削除もれ対応

### DIFF
--- a/github/CODEOWNERS
+++ b/github/CODEOWNERS
@@ -1,3 +1,0 @@
-# https://help.github.com/en/articles/about-code-owners
-
-* @kufu/group-dev-front-linter-reviewers


### PR DESCRIPTION
経緯は以下と推測します。

- #17 で `github/CODEOWNERS` が生まれた。
- 正しくは `github/CODEOWNERS` ではなく `.github/CODEOWNERS` なので #18 で移動した。ただし、`.github/CODEOWNERS` だけ add して `github/CODEOWNERS` を rm しなかったため、両方残ってしまった。