### PR TITLE
feat: a11y-anchor-has-href-attribute を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # eslint-plugin-smarthr
 
+- [a11y-anchor-has-href-attribute](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-anchor-has-href-attribute)
 - [a11y-clickable-element-has-text](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-clickable-element-has-text)
 - [a11y-image-has-alt-attribute](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-image-has-alt-attribute)
 - [a11y-input-has-name-attribute](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-input-has-name-attribute)

--- a/rules/a11y-anchor-has-href-attribute/README.md
+++ b/rules/a11y-anchor-has-href-attribute/README.md
@@ -1,0 +1,35 @@
+# smarthr/a11y-anchor-has-href-attribute
+
+- a, Anchor, Link コンポーネントに href 属性を設定することを促すルールです
+  - href が設定されていないanchor要素は `遷移先が存在しない無効化されたリンク` という扱いになります
+  - URLの変更を行わない場合、責務としても a より button が適切です
+  - URL遷移を行う場合、hrefが設定されていないとキーボード操作やコンテキストメニューからの遷移ができなくなります
+    - これらの操作は href属性を参照します
+  - 無効化されたリンクであることを表したい場合 `href={undefined}` を設定してください
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/a11y-anchor-has-href-attribute': 'error', // 'warn', 'off'
+  },
+}
+```
+
+## ❌ Incorrect
+
+```jsx
+<a>any</a>
+<XxxAnchor>any</XxxAnchor>
+<XxxLink>any</XxxLink>
+<XxxLink href>any</XxxLink>
+```
+
+## ✅ Correct
+
+```jsx
+<a href="https://www.google.com/search">any</a>
+<XxxAnchor href={hoge}>any</XxxAnchor>
+<XxxLink href={undefined}>any</XxxLink>
+```

--- a/rules/a11y-anchor-has-href-attribute/index.js
+++ b/rules/a11y-anchor-has-href-attribute/index.js
@@ -1,0 +1,40 @@
+const { generateTagFormatter } = require('../../libs/format_styled_components')
+
+const EXPECTED_NAMES = {
+  'Anchor$': 'Anchor$',
+  'Link$': 'Link$',
+  '^a$': '(Anchor|Link)$',
+}
+
+const REGEX_TARGET = /(Anchor|Link|^a)$/
+const findHref = (a) => a.name?.name == 'href'
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    schema: [],
+  },
+  create(context) {
+    return {
+      ...generateTagFormatter({ context, EXPECTED_NAMES }),
+      JSXOpeningElement: (node) => {
+        const nodeName = node.name.name || ''
+
+        if (nodeName.match(REGEX_TARGET)) {
+          const href = node.attributes.find(findHref)
+
+          if (!href || !href.value) {
+            context.report({
+              node,
+              message: `${nodeName} に href 属性を設定してください。
+ - onClickなどでページ遷移する場合、href属性に遷移先のURIを設定してください。Cmd + clickなどのキーボードショートカットに対応出来ます。
+ - onClickなどの動作がURLの変更を行わない場合、リンクではなくbuttonでマークアップすることを検討してください。
+ - リンクを無効化することを表したい場合、href属性に undefined を設定してください。`,
+            })
+          }
+        }
+      },
+    }
+  },
+}
+module.exports.schema = []

--- a/test/a11y-anchor-has-href-attribute.js
+++ b/test/a11y-anchor-has-href-attribute.js
@@ -1,0 +1,56 @@
+const rule = require('../rules/a11y-anchor-has-href-attribute')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+})
+
+const generateErrorText = (name) => `${name} に href 属性を設定してください。
+ - onClickなどでページ遷移する場合、href属性に遷移先のURIを設定してください。Cmd + clickなどのキーボードショートカットに対応出来ます。
+ - onClickなどの動作がURLの変更を行わない場合、リンクではなくbuttonでマークアップすることを検討してください。
+ - リンクを無効化することを表したい場合、href属性に undefined を設定してください。`
+
+ruleTester.run('a11y-anchor-has-href-attribute', rule, {
+  valid: [
+    { code: `import styled from 'styled-components'` },
+    { code: `import styled, { css } from 'styled-components'` },
+    { code: `import { css } from 'styled-components'` },
+    { code: 'const HogeAnchor = styled.a``' },
+    { code: 'const HogeLink = styled.a``' },
+    { code: 'const HogeAnchor = styled(Anchor)``' },
+    { code: 'const HogeLink = styled(Link)``' },
+    {
+      code: `<a href="hoge">ほげ</a>`,
+    },
+    {
+      code: `<a href={hoge}>ほげ</a>`,
+    },
+    {
+      code: `<a href={undefined}>ほげ</a>`,
+    },
+    {
+      code: `<HogeAnchor href={hoge}>ほげ</HogeAnchor>`,
+    },
+    {
+      code: `<Link href="hoge">ほげ</Link>`,
+    },
+  ],
+  invalid: [
+    { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
+    { code: 'const Hoge = styled.a``', errors: [ { message: `Hogeを正規表現 "/(Anchor|Link)$/" がmatchする名称に変更してください` } ] },
+    { code: 'const Hoge = styled(Anchor)``', errors: [ { message: `Hogeを正規表現 "/Anchor$/" がmatchする名称に変更してください` } ] },
+    { code: 'const Hoge = styled(Link)``', errors: [ { message: `Hogeを正規表現 "/Link$/" がmatchする名称に変更してください` } ] },
+    { code: `<a></a>`, errors: [{ message: generateErrorText('a') }] },
+    { code: `<a>hoge</a>`, errors: [{ message: generateErrorText('a') }] },
+    { code: `<Anchor>hoge</Anchor>`, errors: [{ message: generateErrorText('Anchor') }] },
+    { code: `<HogeLink>hoge</HogeLink>`, errors: [{ message: generateErrorText('HogeLink') }] },
+    { code: `<HogeLink href>hoge</HogeLink>`, errors: [{ message: generateErrorText('HogeLink') }] },
+  ]
+})


### PR DESCRIPTION
- `hrefが設定されていないanchor要素` を検出し、設定することを促すルールを追加します
- これにより以下の問題が解決します
  - URLの変更が伴わない動作を設定する要素は基本的にaよりbuttonが適切なため、差し替えを促せる
  - URLの変更を伴う動作を設定している場合はhrefを設定することにより、キーボード操作やコンテキストメニューでの遷移に対応できる