### PR TITLE
fix!: best-practice-for-remote-trigger-dialog にリネーム & 特定パターンでバグが起きる問題を修正する

### DIFF
--- a/rules/best-practice-for-remote-trigger-dialog/README.md
+++ b/rules/best-practice-for-remote-trigger-dialog/README.md
@@ -1,6 +1,6 @@
-# smarthr/best-practice-for-remote-trigger-action-dialog
+# smarthr/best-practice-for-remote-trigger-dialog
 
-- RemoteDialogTrigger, RemoteTriggerActionDialog のベストプラクティスをチェックするルールです
+- RemoteDialogTrigger, RemoteTriggerXxxxDialog のベストプラクティスをチェックするルールです
   - `id` もしくは `targetId` にリテラルな文字列以外が設定できなくなります
   - 変数なども使えません
   - これは対応するTriggerとDialogをわかりやすくするためです（検索などが容易になります）
@@ -10,7 +10,7 @@
 ```js
 {
   rules: {
-    'smarthr/best-practice-for-remote-trigger-action-dialog': 'error', // 'warn', 'off'
+    'smarthr/best-practice-for-remote-trigger-dialog': 'error', // 'warn', 'off'
   },
 }
 ```

--- a/rules/best-practice-for-remote-trigger-dialog/index.js
+++ b/rules/best-practice-for-remote-trigger-dialog/index.js
@@ -5,7 +5,7 @@ const EXPECTED_NAMES = {
   'RemoteTrigger(.+)Dialog$': 'RemoteTrigger(.+)Dialog$',
 }
 
-const REGEX_REMOTE_TRIGGER_DIALOG = /RemoteTrigger(.+)Dialog$/
+const REGEX_REMOTE_TRIGGER_DIALOG = /RemoteTrigger(Action|Message|Modeless)Dialog$/
 const REGEX_REMOTE_DIALOG_TRIGGER = /RemoteDialogTrigger$/
 
 module.exports = {
@@ -25,7 +25,7 @@ module.exports = {
           const attrName = regexRemoteTriggerDialog ? 'id' : 'targetId'
           const id = node.attributes.find((a) => a.name?.name === attrName)
 
-          if (id.value.type !== 'Literal') {
+          if (id && id.value.type !== 'Literal') {
             context.report({
               node: id,
               message: `${nodeName}の${attrName}属性には直接文字列を指定してください。

--- a/test/best-practice-for-remote-trigger-dialog.js
+++ b/test/best-practice-for-remote-trigger-dialog.js
@@ -1,4 +1,4 @@
-const rule = require('../rules/best-practice-for-remote-trigger-action-dialog')
+const rule = require('../rules/best-practice-for-remote-trigger-dialog')
 const RuleTester = require('eslint').RuleTester
 
 const ruleTester = new RuleTester({
@@ -12,7 +12,7 @@ const ruleTester = new RuleTester({
   },
 })
 
-ruleTester.run('best-practice-for-remote-trigger-action-dialog', rule, {
+ruleTester.run('best-practice-for-remote-trigger-dialog', rule, {
   valid: [
     { code: `import styled from 'styled-components'` },
     { code: 'const HogeRemoteDialogTrigger = styled(RemoteDialogTrigger)``' },
@@ -31,10 +31,6 @@ ruleTester.run('best-practice-for-remote-trigger-action-dialog', rule, {
   - RemoteTriggerActionDialogはループやDropdown内にTriggerが存在する場合に利用してください
   - ループやDropdown以外にTriggerが設定されている場合、TriggerAndActionDialogを利用してください` } ] },
     { code: '<StyledRemoteDialogTrigger targetId={"fuga"}>open.</StyledRemoteDialogTrigger>', errors: [ { message: `StyledRemoteDialogTriggerのtargetId属性には直接文字列を指定してください。
-  - 変数などは利用できません（これは関連するTriggerとDialogを検索しやすくするためです）
-  - RemoteTriggerActionDialogはループやDropdown内にTriggerが存在する場合に利用してください
-  - ループやDropdown以外にTriggerが設定されている場合、TriggerAndActionDialogを利用してください` } ] },
-    { code: '<RemoteTriggerHogeDialog {...args} id={hoge}>content.</RemoteTriggerHogeDialog>', errors: [ { message: `RemoteTriggerHogeDialogのid属性には直接文字列を指定してください。
   - 変数などは利用できません（これは関連するTriggerとDialogを検索しやすくするためです）
   - RemoteTriggerActionDialogはループやDropdown内にTriggerが存在する場合に利用してください
   - ループやDropdown以外にTriggerが設定されている場合、TriggerAndActionDialogを利用してください` } ] },


### PR DESCRIPTION
- id属性の指定必須であることをチェックするロジックの対象を絞ります
  - RemoteTriggerXxxxDialog系は MessageDialog, ModelessDialog が追加される予定なのでそれに合わせて対象を絞る処理を調整
- id未指定の場合、実行エラーになっていた問題を修正しました
