### PR TITLE
feat: .eslintrc.js などの設定からparserOptions.project が設定されている場合、tsconfig.jsonの読み込み先を変更する

### DIFF
--- a/libs/common.js
+++ b/libs/common.js
@@ -3,13 +3,29 @@ const path = require('path')
 const fs = require('fs')
 
 const replacePaths = (() => {
-  const tsconfig = fs.readFileSync(`${process.cwd()}/tsconfig.json`)
+  const cwd = process.cwd()
+  const eslintrc = (() => {
+    let file = `${cwd}/.eslintrc.js`
+    if (fs.existsSync(file)) {
+      return require(file)
+    }
 
-  if (!tsconfig) {
-    throw new Error('プロジェクトルートにtsconfig.json を設置してください')
+    file = `${cwd}/.eslintrc`
+
+    if (fs.existsSync(file)) {
+      return JSON5.parse(fs.readFileSync(file))
+    }
+
+    return {}
+  })()
+
+  const tsconfigFile = `${cwd}/${eslintrc.parserOptions?.project || 'tsconfig.json'}`
+
+  if (!fs.existsSync(tsconfigFile)) {
+    throw new Error(`${tsconfigFile} を設置してください`)
   }
 
-  const { compilerOptions } = JSON5.parse(tsconfig)
+  const { compilerOptions } = JSON5.parse(fs.readFileSync(tsconfigFile))
 
   if (!compilerOptions || !compilerOptions.paths) {
     throw new Error('tsconfig.json の compilerOptions.paths に `"@/*": ["any_path/*"]` 形式でフロントエンドのroot dir を指定してください')

--- a/rules/format-import-path/README.md
+++ b/rules/format-import-path/README.md
@@ -9,7 +9,7 @@
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
   - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
-  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `parserOptions.project` を設定してください
 - ドメインを識別するために以下の設定を記述する必要があります
   - globalModuleDir
     - 全体で利用するファイルを収めているディレクトリを相対パスで指定します

--- a/rules/format-import-path/README.md
+++ b/rules/format-import-path/README.md
@@ -8,6 +8,8 @@
 ## config
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
+  - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
 - ドメインを識別するために以下の設定を記述する必要があります
   - globalModuleDir
     - 全体で利用するファイルを収めているディレクトリを相対パスで指定します

--- a/rules/no-import-other-domain/README.md
+++ b/rules/no-import-other-domain/README.md
@@ -7,6 +7,8 @@
 ## config
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
+  - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
 - ドメインを識別するために以下の設定を記述する必要があります
   - globalModuleDir
     - 全体で利用するファイルを収めているディレクトリを相対パスで指定します

--- a/rules/no-import-other-domain/README.md
+++ b/rules/no-import-other-domain/README.md
@@ -8,7 +8,7 @@
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
   - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
-  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `parserOptions.project` を設定してください
 - ドメインを識別するために以下の設定を記述する必要があります
   - globalModuleDir
     - 全体で利用するファイルを収めているディレクトリを相対パスで指定します

--- a/rules/redundant-name/README.md
+++ b/rules/redundant-name/README.md
@@ -6,6 +6,8 @@
 ## config
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
+  - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
 - 以下の設定を行えます。全て省略可能です。
   - ignoreKeywords
     - ディレクトリ名から生成されるキーワードに含めたくない文字列を指定します

--- a/rules/redundant-name/README.md
+++ b/rules/redundant-name/README.md
@@ -7,7 +7,7 @@
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
   - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
-  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `parserOptions.project` を設定してください
 - 以下の設定を行えます。全て省略可能です。
   - ignoreKeywords
     - ディレクトリ名から生成されるキーワードに含めたくない文字列を指定します

--- a/rules/require-barrel-import/README.md
+++ b/rules/require-barrel-import/README.md
@@ -1,6 +1,8 @@
 # smarthr/require-barrel-import
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
+  - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
 - importした対象が本来exportされているべきであるbarrel(index.tsなど)が有る場合、import pathの変更を促します
   - 例: Page/parts/Menu/Item の import は Page/parts/Menu から行わせたい
 - ディレクトリ内のindexファイルを捜査し、対象を決定します

--- a/rules/require-barrel-import/README.md
+++ b/rules/require-barrel-import/README.md
@@ -2,7 +2,7 @@
 
 - tsconfig.json の compilerOptions.pathsに '@/*', もしくは '~/*' としてroot path を指定する必要があります
   - tsconfig.json はデフォルトではコマンド実行をしたディレクトリから読み込みます
-  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `.parserOptions.project` を設定してください
+  - tsconfig.json の設置ディレクトリを変更したい場合、 `.eslintrc` などのeslint設定ファイルに `parserOptions.project` を設定してください
 - importした対象が本来exportされているべきであるbarrel(index.tsなど)が有る場合、import pathの変更を促します
   - 例: Page/parts/Menu/Item の import は Page/parts/Menu から行わせたい
 - ディレクトリ内のindexファイルを捜査し、対象を決定します


### PR DESCRIPTION
- tsconfig.json の設置ディレクトリを変更可能にするため、.eslintrc.js の parserOption.project を参照するように変更します