### PR TITLE
feat: a11y-clickable-element-has-text のチェック時、リンク内部に名称の末尾がTextがつくコンポーネントがある場合、チェックを通過するように修正

### DIFF
--- a/rules/a11y-clickable-element-has-text/README.md
+++ b/rules/a11y-clickable-element-has-text/README.md
@@ -37,6 +37,12 @@
 </XxxButton>
 ```
 
+```jsx
+<XxxAnchor>>
+  <XxxTextYyyy />
+</XxxAnchor>
+```
+
 ## ✅ Correct
 
 ```jsx
@@ -66,18 +72,24 @@
 ```
 
 ```jsx
+<XxxAnchor>>
+  <XxxText />
+</XxxAnchor>
+```
+
+```jsx
 /*
 rules: {
   'smarthr/a11y-clickable-element-has-text': [
     'error',
     {
-      componentsWithText: ['AnyComponent'],
+      componentsWithText: ['Hoge'],
     },
   ]
 },
 */
 
 <XxxButton>
-  <AnyComponent />
+  <Hoge />
 </XxxButton>
 ```

--- a/rules/a11y-clickable-element-has-text/index.js
+++ b/rules/a11y-clickable-element-has-text/index.js
@@ -15,12 +15,27 @@ const EXPECTED_NAMES = {
   '(b|B)utton$': 'Button$',
   'Anchor$': 'Anchor$',
   'Link$': 'Link$',
+  'Text$': 'Text$',
+  'Message$': 'Message$',
   '^a$': '(Anchor|Link)$',
 }
 
-const filterFalsyJSXText = (cs) => cs.filter((c) => (
-  !(c.type === 'JSXText' && c.value.match(/^\s*\n+\s*$/))
-))
+const REGEX_NLSP = /^\s*\n+\s*$/
+const REGEX_CLICKABLE_ELEMENT = /^(a|(.*?)Anchor(Button)?|(.*?)Link|(b|B)utton)$/
+const REGEX_SMARTHR_LOGO = /SmartHRLogo$/
+const REGEX_TEXT_COMPONENT = /(Text|Message)$/
+
+const HIT_TYPES_RECURSICVE_SEARCH = ['JSXText', 'JSXExpressionContainer']
+const HIT_TEXT_ATTRS = ['visuallyHiddenText', 'alt']
+
+const filterFalsyJSXText = (cs) => cs.filter(checkFalsyJSXText)
+const checkFalsyJSXText = (c) => (
+  !(c.type === 'JSXText' && c.value.match(REGEX_NLSP))
+)
+
+const message = `a, buttonなどのクリッカブルな要素内にはテキストを設定してください。
+ - 要素内にアイコン、画像のみを設置する場合はaltなどの代替テキスト用属性を指定してください
+ - クリッカブルな要素内に設置しているコンポーネントがテキストを含んでいる場合、"XxxxText" のように末尾に "Text" もしくは "Message" という名称を設定してください`
 
 module.exports = {
   meta: {
@@ -41,69 +56,65 @@ module.exports = {
 
         const node = parentNode.openingElement
 
-        if (!node.name.name || !node.name.name.match(/^(a|(.*?)Anchor(Button)?|(.*?)Link|(b|B)utton)$/)) {
+        if (!node.name.name || !node.name.name.match(REGEX_CLICKABLE_ELEMENT)) {
           return
         }
 
         const recursiveSearch = (c) => {
-          if (['JSXText', 'JSXExpressionContainer'].includes(c.type)) {
+          if (HIT_TYPES_RECURSICVE_SEARCH.includes(c.type)) {
             return true
           }
 
-          if (c.type === 'JSXFragment') {
-            if (c.children && filterFalsyJSXText(c.children).some(recursiveSearch)) {
-              return true
+          switch (c.type) {
+            case 'JSXFragment': {
+              return c.children && filterFalsyJSXText(c.children).some(recursiveSearch)
             }
-
-            return false
-          }
-
-          if (c.type === 'JSXElement') {
-            // // HINT: SmartHRLogo コンポーネントは内部でaltを持っているため対象外にする
-            if (c.openingElement.name.name.match(/SmartHRLogo$/)) {
-              return true
-            }
-
-            if (componentsWithText.includes(c.openingElement.name.name)) {
-              return true
-            }
-
-            // HINT: role & aria-label を同時に設定されている場合は許可
-            let existRole = false
-            let existAriaLabel = false
-            const result = c.openingElement.attributes.reduce((prev, a) =>  {
-              existRole = existRole || (a.name.name === 'role' && a.value.value === 'img')
-              existAriaLabel = existAriaLabel || a.name.name === 'aria-label'
-
-              if (prev) {
-                return prev
+            case 'JSXElement': {
+              // // HINT: SmartHRLogo コンポーネントは内部でaltを持っているため対象外にする
+              if (c.openingElement.name.name.match(REGEX_SMARTHR_LOGO)) {
+                return true
               }
 
-              if (!['visuallyHiddenText', 'alt'].includes(a.name.name)) {
-                return prev
+              const tagName = c.openingElement.name.name
+
+              if (tagName.match(REGEX_TEXT_COMPONENT) || componentsWithText.includes(tagName)) {
+                return true
               }
 
-              return (!!a.value.value || a.value.type === 'JSXExpressionContainer') ? a : prev
-            }, null)
+              // HINT: role & aria-label を同時に設定されている場合は許可
+              let existRole = false
+              let existAriaLabel = false
+              const result = c.openingElement.attributes.reduce((prev, a) =>  {
+                existRole = existRole || (a.name.name === 'role' && a.value.value === 'img')
+                existAriaLabel = existAriaLabel || a.name.name === 'aria-label'
 
-            if (result || (existRole && existAriaLabel)) {
-              return true
-            }
+                if (
+                  prev ||
+                  !HIT_TEXT_ATTRS.includes(a.name.name)
+                ) {
+                  return prev
+                }
 
-            if (c.children && filterFalsyJSXText(c.children).some(recursiveSearch)) {
-              return true
+                return (!!a.value.value || a.value.type === 'JSXExpressionContainer') ? a : prev
+              }, null)
+
+              if (
+                result ||
+                (existRole && existAriaLabel) ||
+                (c.children && filterFalsyJSXText(c.children).some(recursiveSearch))
+              ) {
+                return true
+              }
             }
           }
 
           return false
         }
 
-        const child = filterFalsyJSXText(parentNode.children).find(recursiveSearch)
-
-        if (!child) {
+        if (!filterFalsyJSXText(parentNode.children).find(recursiveSearch)) {
           context.report({
             node,
-            message: 'a, button要素にはテキストを設定してください。要素内にアイコン、画像のみを設置する場合はSmartHR UIのvisuallyHiddenText、通常のHTML要素にはaltなどの代替テキスト用属性を指定してください',
+            message,
           });
         }
       },

--- a/test/a11y-clickable-element-has-text.js
+++ b/test/a11y-clickable-element-has-text.js
@@ -12,7 +12,9 @@ const ruleTester = new RuleTester({
   },
 })
 
-const defaultErrorMessage = 'a, button要素にはテキストを設定してください。要素内にアイコン、画像のみを設置する場合はSmartHR UIのvisuallyHiddenText、通常のHTML要素にはaltなどの代替テキスト用属性を指定してください'
+const defaultErrorMessage = `a, buttonなどのクリッカブルな要素内にはテキストを設定してください。
+ - 要素内にアイコン、画像のみを設置する場合はaltなどの代替テキスト用属性を指定してください
+ - クリッカブルな要素内に設置しているコンポーネントがテキストを含んでいる場合、"XxxxText" のように末尾に "Text" もしくは "Message" という名称を設定してください`
 
 ruleTester.run('a11y-clickable-element-has-text', rule, {
   valid: [
@@ -30,6 +32,8 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
     { code: 'const HogeAnchor = styled.a(() => ``)' },
     { code: 'const HogeAnchor = styled("a")(() => ``)' },
     { code: 'const HogeAnchor = styled(Anchor)(() => ``)' },
+    { code: 'const FugaText = styled(HogeText)(() => ``)' },
+    { code: 'const FugaMessage = styled(HogeMessage)(() => ``)' },
     {
       code: `<a>ほげ</a>`,
     },
@@ -106,6 +110,15 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
       code: `<a><svg role="img" aria-label="hoge" /></a>`,
     },
     {
+      code: `<a><Text /></a>`,
+    },
+    {
+      code: `<a><HogeText /></a>`,
+    },
+    {
+      code: `<a><FormattedMessage /></a>`,
+    },
+    {
       code: `<a><AnyComponent /></a>`,
       options: [{
         componentsWithText: ['AnyComponent']
@@ -126,6 +139,8 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
     { code: 'const Piyo = styled("a")(() => ``)', errors: [ { message: `Piyoを正規表現 "/(Anchor|Link)$/" がmatchする名称に変更してください` } ] },
     { code: 'const Piyo = styled("a")``', errors: [ { message: `Piyoを正規表現 "/(Anchor|Link)$/" がmatchする名称に変更してください` } ] },
     { code: 'const Piyo = styled(Anchor)(() => ``)', errors: [ { message: `Piyoを正規表現 "/Anchor$/" がmatchする名称に変更してください` } ] },
+    { code: 'const Hoge = styled(Text)``', errors: [ { message: `Hogeを正規表現 "/Text$/" がmatchする名称に変更してください` } ]  },
+    { code: 'const Hoge = styled(HogeMessage)``', errors: [ { message: `Hogeを正規表現 "/Message$/" がmatchする名称に変更してください` } ]  },
     {
       code: `<a><img src="hoge.jpg" /></a>`,
       errors: [{ message: defaultErrorMessage }]
@@ -172,6 +187,10 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
     },
     {
       code: `<a><div role="article" aria-label="hoge" /></a>`,
+      errors: [{ message: defaultErrorMessage }]
+    },
+    {
+      code: `<a><TextWithHoge /></a>`,
       errors: [{ message: defaultErrorMessage }]
     },
     {


### PR DESCRIPTION
- `XxxText` のようなコンポーネントをa, button内に設置することはよく有り、それらをいちいち `componentsWithText` で設定することは面倒なのでデフォルトでエラーにならないように調整します。
- `XxxxTextWithYyyy` のような場合もエラーにならないようにすることも検討しましたが、それほど発生頻度が高くないようなので今回は対応しません