### PR TITLE
feat: best-practice-for-dateを調整し、`new Date("YYYY/MM/DD")` のように日付文字列を直接設定している場合 `new Date(YYYY, MM - 1, DD)` に置き換えるfixerを追加

### DIFF
--- a/rules/best-practice-for-date/index.js
+++ b/rules/best-practice-for-date/index.js
@@ -5,10 +5,31 @@ const MESSAGE_PARSE = `Date.parse は実行環境によって結果が異なる�
  - 'new Date(2022, 12 - 1, 31).getTime()' のように数値を個別に指定する
  - dayjsなど、日付系ライブラリを利用する (例: 'dayjs(arg).valueOf()')`
 
+const SEPARATOR = '(\/|-)'
+const DATE_REGEX = new RegExp(`^([0-9]{4})${SEPARATOR}([0-9]{1,2})${SEPARATOR}([0-9]{1,2})`)
+
+const fixAction = (fixer, node, replacedSuffix = '') => {
+  const arg = node.arguments[0]
+
+  if (arg.type == 'Literal') {
+    const parsedArgs = arg.value.match(DATE_REGEX)
+
+    if (parsedArgs) {
+      return fixer.replaceText(
+        node,
+        `new Date(${parsedArgs[1] * 1}, ${parsedArgs[3] * 1} - 1, ${parsedArgs[5] * 1})${replacedSuffix}`
+      )
+    }
+  }
+}
+
+const SCHEMA = []
+
 module.exports = {
   meta: {
     type: 'problem',
-    schema: [],
+    fixable: 'code',
+    schema: SCHEMA,
   },
   create(context) {
     return {
@@ -20,6 +41,7 @@ module.exports = {
           context.report({
             node,
             message: MESSAGE_NEW_DATE,
+            fix: (fixer) => fixAction(fixer, node),
           });
         }
       },
@@ -31,10 +53,11 @@ module.exports = {
           context.report({
             node,
             message: MESSAGE_PARSE,
+            fix: (fixer) => fixAction(fixer, node, '.getTime()'),
           });
         }
       },
     }
   },
 }
-module.exports.schema = []
+module.exports.schema = SCHEMA


### PR DESCRIPTION
- 固定の日付を扱う場合 `new Date('YYYY/MM/DD')`　のように日付文字列を直接渡してしまう場合がある
- 問題になる可能性は低いが、他コードとの一貫性を保つため、 `new Date(YYYY, MM - 1, DD)` に置換するようにfixerを追加します
- 同様に `Date.parse('YYYY-MM-DD')` のような場合も `new Date(YYYY, MM - 1, DD).getTime()` に置換します