### PR TITLE
feat: a11y系ruleにstyled-componentsで既存のコンポーネントなどを拡張する際、誤検知が発生しそうな名称が設定されている場合はエラーにする機能を追加

### DIFF
--- a/libs/format_styled_components.js
+++ b/libs/format_styled_components.js
@@ -73,16 +73,20 @@ const generateTagFormatter = ({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }) => 
           const matcher = extended.match(e)
 
           if (matcher && !base.match(b)) {
+            const expected = matcher[1]
+            const isBareTag = base === base.toLowerCase()
+            const sampleFixBase = `styled${isBareTag ? `.${base}` : `(${base})`}`
+
             context.report({
               node,
               message: m ? m
               .replaceAll('{{extended}}', extended)
-              .replaceAll('{{expected}}', matcher[1]) : `${extended} は ${b} にmatchする名前のコンポーネントを拡張することを期待している名称になっています
- - ${extended} の名称を ${base} を継承していることをわかるような名称に変更してください
- - もしくは ${base} の名称を ${extended} の継承元であることがわかるような名称に変更してください
-   - エラー例: const XxxTitle = styled(YyyHeading)
-   - 成功例1: const XxxHeading = styled(YyyHeading)
-   - 成功例2: const XxxTitle = styled(YyyTitle)`
+              .replaceAll('{{expected}}', expected) : `${extended} は ${b.toString()} にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - ${extended} の名称の末尾が"${expected}" という文字列ではない状態にしつつ、"${base}"を継承していることをわかる名称に変更してください
+ - もしくは"${base}"を"${extended}"の継承元であることがわかるような${isBareTag ? '適切なタグや別コンポーネントに差し替えてください' : '名称に変更するか、適切な別コンポーネントに差し替えてください'}
+   - 修正例1: const ${extended.replace(expected, '')}Xxxx = ${sampleFixBase}
+   - 修正例2: const ${extended}Xxxx = ${sampleFixBase}
+   - 修正例3: const ${extended} = styled(Xxxx${expected})`
             })
           }
         })

--- a/libs/format_styled_components.js
+++ b/libs/format_styled_components.js
@@ -3,8 +3,9 @@ const STYLED_COMPONENTS = `${STYLED_COMPONENTS_METHOD}-components`
 
 const findInvalidImportNameNode = (s) => s.type === 'ImportDefaultSpecifier' && s.local.name !== STYLED_COMPONENTS_METHOD
 
-const generateTagFormatter = ({ context, EXPECTED_NAMES }) => {
+const generateTagFormatter = ({ context, EXPECTED_NAMES, UNEXPECTED_NAMES, unexpectedMessageTemplate }) => {
   const entriesesTagNames = Object.entries(EXPECTED_NAMES).map(([b, e]) => [ new RegExp(b), new RegExp(e) ])
+  const entriesesUnTagNames = UNEXPECTED_NAMES ? Object.entries(UNEXPECTED_NAMES).map(([b, e]) => [ new RegExp(b), new RegExp(e) ]) : []
 
   return {
     ImportDeclaration: (node) => {
@@ -61,6 +62,25 @@ const generateTagFormatter = ({ context, EXPECTED_NAMES }) => {
               node,
               message: `${extended}を正規表現 "${e.toString()}" がmatchする名称に変更してください`,
             });
+          }
+        })
+
+        entriesesUnTagNames.forEach(([b, e]) => {
+          const matcher = extended.match(e)
+
+          if (matcher && !base.match(b)) {
+            context.report({
+              node,
+              message: unexpectedMessageTemplate ? unexpectedMessageTemplate
+              .replaceAll('{{extended}}', extended)
+              .replaceAll('{{expected}}', matcher[1]) : `${extended} は ${b} にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - ${extended} の名称を ${base} を継承していることをわかるような名称に変更してください
+ - もしくは ${base} の名称を ${extended} の継承元であることがわかるような名称に変更してください
+   - エラー例: const XxxTitle = styled(YyyHeading)
+   - 成功例1: const XxxHeading = styled(YyyHeading)
+   - 成功例2: const XxxTitle = styled(YyyTitle)
+              `
+            })
           }
         })
       }

--- a/rules/a11y-anchor-has-href-attribute/index.js
+++ b/rules/a11y-anchor-has-href-attribute/index.js
@@ -28,6 +28,11 @@ const EXPECTED_NAMES = {
   '^a$': '(Anchor|Link)$',
 }
 
+const UNEXPECTED_NAMES = {
+  '(Anchor|^a)$': '(Anchor)$',
+  '(Link|^a)$': '(Link)$',
+}
+
 const REGEX_TARGET = /(Anchor|Link|^a)$/
 const check = (node) => {
   const result = baseCheck(node)
@@ -78,7 +83,7 @@ module.exports = {
   },
   create(context) {
     return {
-      ...generateTagFormatter({ context, EXPECTED_NAMES }),
+      ...generateTagFormatter({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }),
       JSXOpeningElement: (node) => {
         const nodeName = check(node)
 

--- a/rules/a11y-clickable-element-has-text/index.js
+++ b/rules/a11y-clickable-element-has-text/index.js
@@ -20,6 +20,12 @@ const EXPECTED_NAMES = {
   '^a$': '(Anchor|Link)$',
 }
 
+const UNEXPECTED_NAMES = {
+  '(B|^b)utton$': '(Button)$',
+  '(Anchor|^a)$': '(Anchor)$',
+  '(Link|^a)$': '(Link)$',
+}
+
 const REGEX_NLSP = /^\s*\n+\s*$/
 const REGEX_CLICKABLE_ELEMENT = /^(a|(.*?)Anchor(Button)?|(.*?)Link|(b|B)utton)$/
 const REGEX_SMARTHR_LOGO = /SmartHRLogo$/
@@ -47,7 +53,7 @@ module.exports = {
     const componentsWithText = option.componentsWithText || []
 
     return {
-      ...generateTagFormatter({ context, EXPECTED_NAMES }),
+      ...generateTagFormatter({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }),
       JSXElement: (parentNode) => {
         // HINT: 閉じタグが存在しない === テキストノードが存在しない
         if (!parentNode.closingElement) {

--- a/rules/a11y-image-has-alt-attribute/index.js
+++ b/rules/a11y-image-has-alt-attribute/index.js
@@ -7,6 +7,12 @@ const EXPECTED_NAMES = {
   '^(img|svg)$': '(Img|Image|Icon)$',
 }
 
+const UNEXPECTED_NAMES = {
+  '(Img|^(img|svg))$': '(Img)$',
+  '(Image|^(img|svg))$': '(Image)$',
+  '(Icon|^(img|svg))$': '(Icon)$',
+}
+
 const REGEX_IMG = /(img|image)$/i // HINT: Iconは別途テキストが存在する場合が多いためチェックの対象外とする
 
 const findAltAttr = (a) => a.name?.name === 'alt'
@@ -35,7 +41,7 @@ module.exports = {
   },
   create(context) {
     return {
-      ...generateTagFormatter({ context, EXPECTED_NAMES }),
+      ...generateTagFormatter({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }),
       JSXOpeningElement: (node) => {
         if (node.name.name) {
           const matcher = node.name.name.match(REGEX_IMG)

--- a/test/a11y-anchor-has-href-attribute.js
+++ b/test/a11y-anchor-has-href-attribute.js
@@ -53,6 +53,18 @@ ruleTester.run('a11y-anchor-has-href-attribute', rule, {
     { code: 'const Hoge = styled.a``', errors: [ { message: `Hogeを正規表現 "/(Anchor|Link)$/" がmatchする名称に変更してください` } ] },
     { code: 'const Hoge = styled(Anchor)``', errors: [ { message: `Hogeを正規表現 "/Anchor$/" がmatchする名称に変更してください` } ] },
     { code: 'const Hoge = styled(Link)``', errors: [ { message: `Hogeを正規表現 "/Link$/" がmatchする名称に変更してください` } ] },
+    { code: 'const FugaAnchor = styled.div``', errors: [ { message: `FugaAnchor は /(Anchor|^a)$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - FugaAnchor の名称の末尾が"Anchor" という文字列ではない状態にしつつ、"div"を継承していることをわかる名称に変更してください
+ - もしくは"div"を"FugaAnchor"の継承元であることがわかるような適切なタグや別コンポーネントに差し替えてください
+   - 修正例1: const FugaXxxx = styled.div
+   - 修正例2: const FugaAnchorXxxx = styled.div
+   - 修正例3: const FugaAnchor = styled(XxxxAnchor)` } ] },
+    { code: 'const FugaLink = styled.p``', errors: [ { message: `FugaLink は /(Link|^a)$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - FugaLink の名称の末尾が"Link" という文字列ではない状態にしつつ、"p"を継承していることをわかる名称に変更してください
+ - もしくは"p"を"FugaLink"の継承元であることがわかるような適切なタグや別コンポーネントに差し替えてください
+   - 修正例1: const FugaXxxx = styled.p
+   - 修正例2: const FugaLinkXxxx = styled.p
+   - 修正例3: const FugaLink = styled(XxxxLink)` } ] },
     { code: `<a></a>`, errors: [{ message: generateErrorText('a') }] },
     { code: `<a>hoge</a>`, errors: [{ message: generateErrorText('a') }] },
     { code: `<Anchor>hoge</Anchor>`, errors: [{ message: generateErrorText('Anchor') }] },

--- a/test/a11y-clickable-element-has-text.js
+++ b/test/a11y-clickable-element-has-text.js
@@ -141,6 +141,24 @@ ruleTester.run('a11y-clickable-element-has-text', rule, {
     { code: 'const Piyo = styled(Anchor)(() => ``)', errors: [ { message: `Piyoを正規表現 "/Anchor$/" がmatchする名称に変更してください` } ] },
     { code: 'const Hoge = styled(Text)``', errors: [ { message: `Hogeを正規表現 "/Text$/" がmatchする名称に変更してください` } ]  },
     { code: 'const Hoge = styled(HogeMessage)``', errors: [ { message: `Hogeを正規表現 "/Message$/" がmatchする名称に変更してください` } ]  },
+    { code: 'const StyledButton = styled.div``', errors: [ { message: `StyledButton は /(B|^b)utton$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - StyledButton の名称の末尾が"Button" という文字列ではない状態にしつつ、"div"を継承していることをわかる名称に変更してください
+ - もしくは"div"を"StyledButton"の継承元であることがわかるような適切なタグや別コンポーネントに差し替えてください
+   - 修正例1: const StyledXxxx = styled.div
+   - 修正例2: const StyledButtonXxxx = styled.div
+   - 修正例3: const StyledButton = styled(XxxxButton)` } ]  },
+    { code: 'const HogeAnchor = styled(Fuga)``', errors: [ { message: `HogeAnchor は /(Anchor|^a)$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - HogeAnchor の名称の末尾が"Anchor" という文字列ではない状態にしつつ、"Fuga"を継承していることをわかる名称に変更してください
+ - もしくは"Fuga"を"HogeAnchor"の継承元であることがわかるような名称に変更するか、適切な別コンポーネントに差し替えてください
+   - 修正例1: const HogeXxxx = styled(Fuga)
+   - 修正例2: const HogeAnchorXxxx = styled(Fuga)
+   - 修正例3: const HogeAnchor = styled(XxxxAnchor)` } ]  },
+    { code: 'const HogeLink = styled.p``', errors: [ { message: `HogeLink は /(Link|^a)$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - HogeLink の名称の末尾が"Link" という文字列ではない状態にしつつ、"p"を継承していることをわかる名称に変更してください
+ - もしくは"p"を"HogeLink"の継承元であることがわかるような適切なタグや別コンポーネントに差し替えてください
+   - 修正例1: const HogeXxxx = styled.p
+   - 修正例2: const HogeLinkXxxx = styled.p
+   - 修正例3: const HogeLink = styled(XxxxLink)` } ]  },
     {
       code: `<a><img src="hoge.jpg" /></a>`,
       errors: [{ message: defaultErrorMessage }]

--- a/test/a11y-heading-in-sectioning-content.js
+++ b/test/a11y-heading-in-sectioning-content.js
@@ -67,11 +67,17 @@ ruleTester.run('a11y-heading-in-sectioning-content', rule, {
  - childrenにHeadingを含み、アウトラインの範囲を指定するためのコンポーネントならば、smarthr-ui/Articleをexendしてください
    - "styled(Xxxx)" 形式の場合、拡張元であるXxxxコンポーネントの名称の末尾に"Article"を設定し、そのコンポーネント内でsmarthr-ui/Articleを利用してください` } ] },
     { code: 'const StyledHeading = styled(Hoge)``', errors: [ { message: `StyledHeading は /(Heading|^h(1|2|3|4|5|6))$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
- - StyledHeading の名称を Hoge を継承していることをわかるような名称に変更してください
- - もしくは Hoge の名称を StyledHeading の継承元であることがわかるような名称に変更してください
-   - エラー例: const XxxTitle = styled(YyyHeading)
-   - 成功例1: const XxxHeading = styled(YyyHeading)
-   - 成功例2: const XxxTitle = styled(YyyTitle)` } ] },
+ - StyledHeading の名称の末尾が"Heading" という文字列ではない状態にしつつ、"Hoge"を継承していることをわかる名称に変更してください
+ - もしくは"Hoge"を"StyledHeading"の継承元であることがわかるような名称に変更するか、適切な別コンポーネントに差し替えてください
+   - 修正例1: const StyledXxxx = styled(Hoge)
+   - 修正例2: const StyledHeadingXxxx = styled(Hoge)
+   - 修正例3: const StyledHeading = styled(XxxxHeading)` } ] },
+    { code: 'const StyledHeading = styled.div``', errors: [ { message: `StyledHeading は /(Heading|^h(1|2|3|4|5|6))$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - StyledHeading の名称の末尾が"Heading" という文字列ではない状態にしつつ、"div"を継承していることをわかる名称に変更してください
+ - もしくは"div"を"StyledHeading"の継承元であることがわかるような適切なタグや別コンポーネントに差し替えてください
+   - 修正例1: const StyledXxxx = styled.div
+   - 修正例2: const StyledHeadingXxxx = styled.div
+   - 修正例3: const StyledHeading = styled(XxxxHeading)` } ] },
     { code: '<><PageHeading>hoge</PageHeading><PageHeading>fuga</PageHeading></>', errors: [ { message: pageMessage } ] },
     { code: '<Heading>hoge</Heading>', errors: [ { message } ] },
     { code: '<><Heading>hoge</Heading><Heading>fuga</Heading></>', errors: [ { message }, { message } ] },

--- a/test/a11y-heading-in-sectioning-content.js
+++ b/test/a11y-heading-in-sectioning-content.js
@@ -58,6 +58,14 @@ ruleTester.run('a11y-heading-in-sectioning-content', rule, {
     { code: 'const StyledAside = styled.aside``', errors: [ { message: `"aside"を利用せず、smarthr-ui/Asideを拡張してください。Headingのレベルが自動計算されるようになります。(例: "styled.aside" -> "styled(Aside)")` } ] },
     { code: 'const StyledNav = styled.nav``', errors: [ { message: `"nav"を利用せず、smarthr-ui/Navを拡張してください。Headingのレベルが自動計算されるようになります。(例: "styled.nav" -> "styled(Nav)")` } ] },
     { code: 'const StyledSection = styled.section``', errors: [ { message: `"section"を利用せず、smarthr-ui/Sectionを拡張してください。Headingのレベルが自動計算されるようになります。(例: "styled.section" -> "styled(Section)")` } ] },
+    { code: 'const StyledSection = styled.div``', errors: [ { message: `StyledSection は smarthr-ui/Section をextendすることを期待する名称になっています
+ - childrenにHeadingを含まない場合、コンポーネントの名称から"Section"を取り除いてください
+ - childrenにHeadingを含み、アウトラインの範囲を指定するためのコンポーネントならば、smarthr-ui/Sectionをexendしてください
+   - "styled(Xxxx)" 形式の場合、拡張元であるXxxxコンポーネントの名称の末尾に"Section"を設定し、そのコンポーネント内でsmarthr-ui/Sectionを利用してください` } ] },
+    { code: 'const StyledArticle = styled(Hoge)``', errors: [ { message: `StyledArticle は smarthr-ui/Article をextendすることを期待する名称になっています
+ - childrenにHeadingを含まない場合、コンポーネントの名称から"Article"を取り除いてください
+ - childrenにHeadingを含み、アウトラインの範囲を指定するためのコンポーネントならば、smarthr-ui/Articleをexendしてください
+   - "styled(Xxxx)" 形式の場合、拡張元であるXxxxコンポーネントの名称の末尾に"Article"を設定し、そのコンポーネント内でsmarthr-ui/Articleを利用してください` } ] },
     { code: '<><PageHeading>hoge</PageHeading><PageHeading>fuga</PageHeading></>', errors: [ { message: pageMessage } ] },
     { code: '<Heading>hoge</Heading>', errors: [ { message } ] },
     { code: '<><Heading>hoge</Heading><Heading>fuga</Heading></>', errors: [ { message }, { message } ] },

--- a/test/a11y-image-has-alt-attribute.js
+++ b/test/a11y-image-has-alt-attribute.js
@@ -32,7 +32,7 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: 'const HogeIcon = styled.svg``' },
     { code: 'const HogeImg = styled(Img)``' },
     { code: 'const HogeImage = styled(Image)``' },
-    { code: 'const HogeIcon = styled(ICon)``' },
+    { code: 'const HogeIcon = styled(Icon)``' },
     { code: '<img alt="hoge" />' },
     { code: '<HogeImg alt="hoge" />' },
     { code: '<HogeImage alt="hoge" />' },
@@ -46,6 +46,24 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: 'const Hoge = styled(Icon)``', errors: [ { message: `Hogeを正規表現 "/Icon$/" がmatchする名称に変更してください` } ] },
     { code: 'const Hoge = styled(Img)``', errors: [ { message: `Hogeを正規表現 "/Img$/" がmatchする名称に変更してください` } ] },
     { code: 'const Hoge = styled(Image)``', errors: [ { message: `Hogeを正規表現 "/Image$/" がmatchする名称に変更してください` } ] },
+    { code: 'const StyledImage = styled.span``', errors: [ { message: `StyledImage は /(Image|^(img|svg))$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - StyledImage の名称の末尾が"Image" という文字列ではない状態にしつつ、"span"を継承していることをわかる名称に変更してください
+ - もしくは"span"を"StyledImage"の継承元であることがわかるような適切なタグや別コンポーネントに差し替えてください
+   - 修正例1: const StyledXxxx = styled.span
+   - 修正例2: const StyledImageXxxx = styled.span
+   - 修正例3: const StyledImage = styled(XxxxImage)` } ] },
+    { code: 'const StyledImg = styled(Hoge)``', errors: [ { message: `StyledImg は /(Img|^(img|svg))$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - StyledImg の名称の末尾が"Img" という文字列ではない状態にしつつ、"Hoge"を継承していることをわかる名称に変更してください
+ - もしくは"Hoge"を"StyledImg"の継承元であることがわかるような名称に変更するか、適切な別コンポーネントに差し替えてください
+   - 修正例1: const StyledXxxx = styled(Hoge)
+   - 修正例2: const StyledImgXxxx = styled(Hoge)
+   - 修正例3: const StyledImg = styled(XxxxImg)` } ] },
+    { code: 'const FugaIcon = styled(Fuga)``', errors: [ { message: `FugaIcon は /(Icon|^(img|svg))$/ にmatchする名前のコンポーネントを拡張することを期待している名称になっています
+ - FugaIcon の名称の末尾が"Icon" という文字列ではない状態にしつつ、"Fuga"を継承していることをわかる名称に変更してください
+ - もしくは"Fuga"を"FugaIcon"の継承元であることがわかるような名称に変更するか、適切な別コンポーネントに差し替えてください
+   - 修正例1: const FugaXxxx = styled(Fuga)
+   - 修正例2: const FugaIconXxxx = styled(Fuga)
+   - 修正例3: const FugaIcon = styled(XxxxIcon)` } ] },
     { code: '<img />', errors: [ { message: messageNotExistAlt } ] },
     { code: '<HogeImage alt="" />', errors: [ { message: messageNullAlt } ] },
     { code: '<hoge><image /></hoge>', errors: [ { message: messageNotExistAlt } ] },


### PR DESCRIPTION
- styled-componentsでコンポーネントを拡張する際、機能・役割を勘違いしそうな名称がついている場合エラーにします
  - 例: `const HogeAnchor = styled.div` はNG
  - 例: `const HogeAnchorWrapper = styled.div` はOK