### PR TITLE
feat: feat: a11y-xxx-has-yyy-attributeにcheckTypeオプションを追加にcheckTypeオプションを追加

### DIFF
--- a/rules/a11y-anchor-has-href-attribute/README.md
+++ b/rules/a11y-anchor-has-href-attribute/README.md
@@ -6,13 +6,17 @@
   - URL遷移を行う場合、hrefが設定されていないとキーボード操作やコンテキストメニューからの遷移ができなくなります
     - これらの操作は href属性を参照します
   - 無効化されたリンクであることを表したい場合 `href={undefined}` を設定してください
+- checkTypeオプションに 'smart' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
 
 ## rules
 
 ```js
 {
   rules: {
-    'smarthr/a11y-anchor-has-href-attribute': 'error', // 'warn', 'off'
+    'smarthr/a11y-anchor-has-href-attribute': [
+      'error', // 'warn', 'off'
+      // { checkType: 'always' } /* 'always' || 'smart' */
+    ]
   },
 }
 ```
@@ -24,6 +28,10 @@
 <XxxAnchor>any</XxxAnchor>
 <XxxLink>any</XxxLink>
 <XxxLink href>any</XxxLink>
+
+// checkType: 'always'
+<XxxAnchor {...args} />
+<XxxLink {...args} any="any" />
 ```
 
 ## ✅ Correct
@@ -38,4 +46,8 @@
 
 // react-router-domを利用している場合
 <Link to={hoge}>any</Link>
+
+// checkType: 'smart'
+<XxxAnchor {...args} />
+<XxxLink {...args} any="any" />
 ```

--- a/rules/a11y-image-has-alt-attribute/README.md
+++ b/rules/a11y-image-has-alt-attribute/README.md
@@ -1,13 +1,17 @@
 # smarthr/a11y-image-has-alt-attribute
 
 - 画像やアイコンにalt属性を設定することを強制するルールです
+- checkTypeオプションに 'smart' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
 
 ## rules
 
 ```js
 {
   rules: {
-    'smarthr/a11y-image-has-alt-attribute': 'error', // 'warn', 'off'
+    'smarthr/a11y-image-has-alt-attribute': [
+      'error', // 'warn', 'off'
+      // { checkType: 'always' } /* 'always' || 'smart' */
+    ]
   },
 }
 ```
@@ -24,6 +28,11 @@
 ```
 ```jsx
 <Icon />
+```
+```jsx
+// checkType: 'always'
+<XxxImage {...args} />
+<YyyIcon {...args} any="any" />
 ```
 ```jsx
 import styled from 'styled-components'
@@ -45,6 +54,11 @@ const StyledPiyo = styled(Icon)``
 ```
 ```jsx
 <Icon alt="message" />
+```
+```jsx
+// checkType: 'smart'
+<XxxImage {...args} />
+<YyyIcon {...args} any="any" />
 ```
 ```jsx
 import styled from 'styled-components'

--- a/rules/a11y-input-has-name-attribute/README.md
+++ b/rules/a11y-input-has-name-attribute/README.md
@@ -4,13 +4,17 @@
   - input は name を設定することでブラウザの補完機能が有効になる可能性が高まります。
     - 補完機能はブラウザによって異なるため、補完される可能性が上がるよう、name には半角英数の小文字・大文字と一部記号(`_ , [, ]`)のみ利用可能です。
   - input[type="radio"] は name を適切に設定することでラジオグループが確立され、キーボード操作しやすくなる等のメリットがあります。
+- checkTypeオプションに 'smart' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
 
 ## rules
 
 ```js
 {
   rules: {
-    'smarthr/a11y-input-has-name-attribute': 'error', // 'warn', 'off'
+    'smarthr/a11y-input-has-name-attribute': [
+      'error', // 'warn', 'off'
+      // { checkType: 'always' } /* 'always' || 'smart' */
+    ]
   },
 }
 ```
@@ -23,6 +27,10 @@
 <input type="text" />
 <Textarea />
 <Select />
+
+// checkType: 'always'
+<AnyInput {...args} />
+<AnyInput {...args} any="any" />
 ```
 
 
@@ -42,6 +50,10 @@ const StyledPiyo = styled(RadioButton)``;
 <input type="text" name="any" />
 <Textarea name="some" />
 <Select name="piyo" />
+
+// checkType: 'smart'
+<AnyInput {...args} />
+<AnyInput {...args} any="any" />
 ```
 
 ```jsx

--- a/test/a11y-anchor-has-href-attribute.js
+++ b/test/a11y-anchor-has-href-attribute.js
@@ -29,24 +29,13 @@ ruleTester.run('a11y-anchor-has-href-attribute', rule, {
     { code: 'const HogeLink = styled.a``' },
     { code: 'const HogeAnchor = styled(Anchor)``' },
     { code: 'const HogeLink = styled(Link)``' },
-    {
-      code: `<a href="hoge">ほげ</a>`,
-    },
-    {
-      code: `<a href={hoge}>ほげ</a>`,
-    },
-    {
-      code: `<a href={undefined}>ほげ</a>`,
-    },
-    {
-      code: `<HogeAnchor href={hoge}>ほげ</HogeAnchor>`,
-    },
-    {
-      code: `<Link href="hoge">ほげ</Link>`,
-    },
-    {
-      code: `<Link href="#fuga">ほげ</Link>`,
-    },
+    { code: `<a href="hoge">ほげ</a>` },
+    { code: `<a href={hoge}>ほげ</a>` },
+    { code: `<a href={undefined}>ほげ</a>` },
+    { code: `<HogeAnchor href={hoge}>ほげ</HogeAnchor>` },
+    { code: `<Link href="hoge">ほげ</Link>` },
+    { code: `<Link href="#fuga">ほげ</Link>` },
+    { code: '<AnyAnchor {...args1} />', options: [{ checkType: 'smart' }] },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
@@ -65,5 +54,7 @@ ruleTester.run('a11y-anchor-has-href-attribute', rule, {
     { code: `<HogeLink href={''}>hoge</HogeLink>`, errors: [{ message: generateErrorText('HogeLink') }] },
     { code: `<HogeLink href="#">hoge</HogeLink>`, errors: [{ message: generateErrorText('HogeLink') }] },
     { code: `<HogeLink href={'#'}>hoge</HogeLink>`, errors: [{ message: generateErrorText('HogeLink') }] },
+    { code: '<AnyAnchor {...args1} />', errors: [{ message: generateErrorText('AnyAnchor') }] },
+    { code: '<AnyAnchor {...args1} />', options: [{ checkType: 'always' }], errors: [{ message: generateErrorText('AnyAnchor') }] },
   ]
 })

--- a/test/a11y-image-has-alt-attribute.js
+++ b/test/a11y-image-has-alt-attribute.js
@@ -38,6 +38,7 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: '<HogeImage alt="hoge" />' },
     { code: '<HogeIcon />' },
     { code: '<svg><image /></svg>' },
+    { code: '<AnyImg {...hoge} />', options: [{ checkType: 'smart' }] },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
@@ -49,5 +50,7 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: '<img />', errors: [ { message: messageNotExistAlt } ] },
     { code: '<HogeImage alt="" />', errors: [ { message: messageNullAlt } ] },
     { code: '<hoge><image /></hoge>', errors: [ { message: messageNotExistAlt } ] },
+    { code: '<AnyImg {...hoge} />', errors: [ { message: messageNotExistAlt } ]  },
+    { code: '<AnyImg {...hoge} />', options: [{ checkType: 'always' }], errors: [ { message: messageNotExistAlt } ] },
   ]
 })

--- a/test/a11y-input-has-name-attribute.js
+++ b/test/a11y-input-has-name-attribute.js
@@ -37,6 +37,9 @@ ruleTester.run('a11y-input-has-name-attribute', rule, {
     { code: '<HogeTextarea name="hoge" />' },
     { code: '<select name="hoge" />' },
     { code: '<Select name="hoge[0][Fuga]" />' },
+    { code: '<Input {...hoge} />', options: [{ checkType: 'smart' }] },
+    { code: '<Input {...args1} {...args2} />', options: [{ checkType: 'smart' }] },
+    { code: '<Input {...args} hoge="fuga" />', options: [{ checkType: 'smart' }] },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
@@ -56,5 +59,11 @@ ruleTester.run('a11y-input-has-name-attribute', rule, {
     { code: '<HogeTextarea />', errors: [ { message: `HogeTextarea にname属性を指定してください${MESSAGE_SUFFIX}` } ] },
     { code: '<input type="radio" name="ほげ" />', errors: [ { message: 'input のname属性の値(ほげ)はブラウザの自動補完が適切に行えない可能性があるため"/^[a-zA-Z0-9_\\[\\]]+$/"にmatchするフォーマットで命名してください' } ] },
     { code: '<select name="hoge[fuga][0][あいうえお]" />', errors: [ { message: 'select のname属性の値(hoge[fuga][0][あいうえお])はブラウザの自動補完が適切に行えない可能性があるため"/^[a-zA-Z0-9_\\[\\]]+$/"にmatchするフォーマットで命名してください' } ] },
+    { code: '<Input {...hoge} />', errors: [ { message: `Input にname属性を指定してください
+ - ブラウザの自動補完が有効化されるなどのメリットがあります
+ - より多くのブラウザが自動補完を行える可能性を上げるため、\"/^[a-zA-Z0-9_\\[\\]]+$/\"にmatchするフォーマットで命名してください` } ] },
+    { code: '<Input {...hoge} hoge="fuga" />', options: [{ checkType: 'always' }], errors: [ { message: `Input にname属性を指定してください
+ - ブラウザの自動補完が有効化されるなどのメリットがあります
+ - より多くのブラウザが自動補完を行える可能性を上げるため、\"/^[a-zA-Z0-9_\\[\\]]+$/\"にmatchするフォーマットで命名してください` } ] },
   ],
 });


### PR DESCRIPTION
- a11y-xxxx-has-yyyy-attribute は `spread attribute に yyyy属性が含まれている` 場合に対応出来なかった
- optionで `checkType: 'smart'` を指定した場合、対象要素に spread attribute が指定されている場合はcorrectになるようにします