### PR TITLE
fix: a11y-heading-in-sectioning-content でHeadingをHeading以外として利用する場合のチェックを追加

### DIFF
--- a/libs/format_styled_components.js
+++ b/libs/format_styled_components.js
@@ -54,6 +54,10 @@ const generateTagFormatter = ({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }) => 
           case callee.object?.name:
             base = callee.property.name
             break
+          case callee.object?.callee?.name:
+            const arg = callee.object.arguments[0]
+            base = arg.name || arg.value
+            break
         }
       }
 
@@ -95,4 +99,4 @@ const generateTagFormatter = ({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }) => 
   }
 }
 
-module.exports = { generateTagFormatter }
+module.exports = { generateTagFormatter, STYLED_COMPONENTS_METHOD }


### PR DESCRIPTION
- Headingコンポーネントのtag属性に span, legendのいずれかを指定している場合、見出しではなくなるため、見出しではないことがわかるコンポーネント名をつけることを強制します
- その際、styled-componentsのattrsでtag属性を指定することを推奨するエラーなどを表示するようにします