### PR TITLE
feat: best-practice-for-button-elementを追加

### DIFF
--- a/rules/best-practice-for-button-element/README.md
+++ b/rules/best-practice-for-button-element/README.md
@@ -1,0 +1,35 @@
+# smarthr/best-practice-for-button-element
+
+- button要素の利用を禁止し、smarthr/Button、もしくはsmarthr/UnstyledButtonの利用を促すルールです
+- button要素のtype属性のデフォルトは 'submit' であり、これはform要素にbuttonを設置すると、clickでformをsubmitする状態になります
+- 上記挙動は開発者が意図しづらいため、smarthr/Button, smarthr/UnstyledButtonはtype属性のデフォルトを 'button' に変更しています
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/best-practice-for-button-element': 'error', // 'warn', 'off'
+  },
+}
+```
+
+## ❌ Incorrect
+
+```js
+<button>click</button>
+
+const AnyButton = styled.button``
+```
+
+## ✅ Correct
+
+
+```js
+<button type="button">click</button>
+<button type="submit">click</button>
+<Button>click</Button>
+<AnyButton>click</AnyButton>
+
+const AnyButton = styled(Button)``
+```

--- a/rules/best-practice-for-button-element/index.js
+++ b/rules/best-practice-for-button-element/index.js
@@ -1,0 +1,43 @@
+const { checkImportStyledComponents, getStyledComponentBaseName } = require('../../libs/format_styled_components')
+
+const ERRORMESSAGE_SUFFIX = `
+ - button要素のtype属性のデフォルトは "submit" のため、button要素がformでラップされていると意図しないsubmitを引き起こす可能性があります
+ - smarthr-ui/Button, smarthr-ui/UnstyledButtonのtype属性のデフォルトは "button" になっているため、buttonから置き換えることをおすすめします`
+const ERRORMESSAGE_REQUIRED_TYPE_ATTR = `button要素を利用する場合、type属性に "button" もしくは "submit" を指定してください${ERRORMESSAGE_SUFFIX}`
+const ERRORMESSAGE_PROHIBIT_STYLED = `"styled.button" の直接利用をやめ、smarthr-ui/Button、もしくはsmarthr-ui/UnstyledButtonを利用してください${ERRORMESSAGE_SUFFIX}`
+
+const findTypeAttr = (a) => a.type === 'JSXAttribute' && a.name.name === 'type'
+
+const SCHEMA = []
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    schema: SCHEMA,
+  },
+  create(context) {
+    return {
+      ImportDeclaration: (node) => {
+        checkImportStyledComponents(node, context)
+      },
+      JSXOpeningElement: (node) => {
+        if (node.name.name === 'button' && !node.attributes.find(findTypeAttr)) {
+          context.report({
+            node,
+            message: ERRORMESSAGE_REQUIRED_TYPE_ATTR,
+          });
+        }
+      },
+      VariableDeclarator: (node) => {
+        if (getStyledComponentBaseName(node) === 'button') {
+          context.report({
+            node,
+            message: ERRORMESSAGE_PROHIBIT_STYLED,
+          });
+        }
+      },
+    }
+  },
+}
+module.exports.schema = SCHEMA

--- a/test/best-practice-for-button-element.js
+++ b/test/best-practice-for-button-element.js
@@ -1,0 +1,38 @@
+const rule = require('../rules/best-practice-for-button-element')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+})
+
+const ERRORMESSAGE_REQUIRED_TYPE_ATTR = `button要素を利用する場合、type属性に "button" もしくは "submit" を指定してください
+ - button要素のtype属性のデフォルトは "submit" のため、button要素がformでラップされていると意図しないsubmitを引き起こす可能性があります
+ - smarthr-ui/Button, smarthr-ui/UnstyledButtonのtype属性のデフォルトは "button" になっているため、buttonから置き換えることをおすすめします`
+const ERRORMESSAGE_PROHIBIT_STYLED = `"styled.button" の直接利用をやめ、smarthr-ui/Button、もしくはsmarthr-ui/UnstyledButtonを利用してください
+ - button要素のtype属性のデフォルトは "submit" のため、button要素がformでラップされていると意図しないsubmitを引き起こす可能性があります
+ - smarthr-ui/Button, smarthr-ui/UnstyledButtonのtype属性のデフォルトは "button" になっているため、buttonから置き換えることをおすすめします`
+
+ruleTester.run('best-practice-for-button-element', rule, {
+  valid: [
+    { code: `import styled from 'styled-components'` },
+    { code: `import styled, { css } from 'styled-components'` },
+    { code: `<Button />` },
+    { code: `<Button>ほげ</Button>` },
+    { code: `<AnyButton>ほげ</AnyButton>` },
+    { code: `<button type="button">any</button>` },
+    { code: `<button type="submit">any</button>` },
+    { code: 'const HogeButton = styled(HogeButton)``' },
+  ],
+  invalid: [
+    { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
+    { code: `<button>ほげ</button>`, errors: [ { message: ERRORMESSAGE_REQUIRED_TYPE_ATTR } ] },
+    { code: 'const HogeButton = styled.button``', errors: [ { message: ERRORMESSAGE_PROHIBIT_STYLED } ] },
+  ]
+})


### PR DESCRIPTION
- button要素のtype属性のデフォルト値が 'submit' であることが `form要素でラップしている場合clickでsubmitされてしまう` という開発者が意図しづらい問題を引き起こすことがあるため、防ぎたい
  - styled-componentsなどで `HogeButton` ようにbutton要素そのままではない場合などに顕著に指定ミスが起こりがち
 - smarthr-ui/Buttonなどは上記問題に対応するため、type属性のデフォルト値をbuttonにしてあるため、以下のチェックを行うようにしたい
   - button要素を直接利用する場合はtype属性の設定を必須にする
   - HogeButtonなどのように、コンポーネントの場合はチェックしない
   - styled-componentsでstyled.bottonの直接利用を禁止する