### PR TITLE
fix!: spread attributesが指定されている場合、ruleをcorrectにする smart オプションを allow-spread-attributes オプションにリネームする

### DIFF
--- a/rules/a11y-anchor-has-href-attribute/README.md
+++ b/rules/a11y-anchor-has-href-attribute/README.md
@@ -6,7 +6,7 @@
   - URL遷移を行う場合、hrefが設定されていないとキーボード操作やコンテキストメニューからの遷移ができなくなります
     - これらの操作は href属性を参照します
   - 無効化されたリンクであることを表したい場合 `href={undefined}` を設定してください
-- checkTypeオプションに 'smart' を指定することで spread attributeが設定されている場合はcorrectに出来ます
+- checkTypeオプションに 'allow-spread-attributes' を指定することで spread attributeが設定されている場合はcorrectに出来ます
 - react-router-dom packageを利用している場合、a要素にto属性が指定されている場合、href属性が指定されているものとして許容します
 - next/link コンポーネント直下のa要素にhref属性が指定されていないことを許容します
 
@@ -17,7 +17,7 @@
   rules: {
     'smarthr/a11y-anchor-has-href-attribute': [
       'error', // 'warn', 'off'
-      // { checkType: 'always' } /* 'always' || 'smart' */
+      // { checkType: 'always' } /* 'always' || 'allow-spread-attributes' */
     ]
   },
 }
@@ -49,7 +49,7 @@
 // react-router-domを利用している場合
 <Link to={hoge}>any</Link>
 
-// checkType: 'smart'
+// checkType: 'allow-spread-attributes'
 <XxxAnchor {...args} />
 <XxxLink {...args} any="any" />
 ```

--- a/rules/a11y-anchor-has-href-attribute/index.js
+++ b/rules/a11y-anchor-has-href-attribute/index.js
@@ -45,7 +45,7 @@ const baseCheck = (node, checkType) => {
   if (
     nodeName.match(REGEX_TARGET) &&
     checkExistAttribute(node, findHrefAttribute) &&
-    (checkType !== 'smart' || !node.attributes.some(findSpreadAttr))
+    (checkType !== 'allow-spread-attributes' || !node.attributes.some(findSpreadAttr))
   ) {
     return nodeName
   }
@@ -87,7 +87,7 @@ const SCHEMA = [
   {
     type: 'object',
     properties: {
-      checkType: { type: 'string', enum: ['always', 'smart'], default: 'always' },
+      checkType: { type: 'string', enum: ['always', 'allow-spread-attributes'], default: 'always' },
     },
     additionalProperties: false,
   }

--- a/rules/a11y-image-has-alt-attribute/README.md
+++ b/rules/a11y-image-has-alt-attribute/README.md
@@ -1,7 +1,7 @@
 # smarthr/a11y-image-has-alt-attribute
 
 - 画像やアイコンにalt属性を設定することを強制するルールです
-- checkTypeオプションに 'smart' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
+- checkTypeオプションに 'allow-spread-attributes' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
 
 ## rules
 
@@ -10,7 +10,7 @@
   rules: {
     'smarthr/a11y-image-has-alt-attribute': [
       'error', // 'warn', 'off'
-      // { checkType: 'always' } /* 'always' || 'smart' */
+      // { checkType: 'always' } /* 'always' || 'allow-spread-attributes' */
     ]
   },
 }
@@ -56,7 +56,7 @@ const StyledPiyo = styled(Icon)``
 <Icon alt="message" />
 ```
 ```jsx
-// checkType: 'smart'
+// checkType: 'allow-spread-attributes'
 <XxxImage {...args} />
 <YyyIcon {...args} any="any" />
 ```

--- a/rules/a11y-image-has-alt-attribute/index.js
+++ b/rules/a11y-image-has-alt-attribute/index.js
@@ -42,7 +42,7 @@ const SCHEMA = [
   {
     type: 'object',
     properties: {
-      checkType: { type: 'string', enum: ['always', 'smart'], default: 'always' },
+      checkType: { type: 'string', enum: ['always', 'allow-spread-attributes'], default: 'always' },
     },
     additionalProperties: false,
   }
@@ -76,7 +76,7 @@ module.exports = {
                   !isWithinSvgJsxElement(node.parent)
                 ) &&
                 (
-                  checkType !== 'smart' ||
+                  checkType !== 'allow-spread-attributes' ||
                   !node.attributes.some(findSpreadAttr)
                 )
               ) {

--- a/rules/a11y-input-has-name-attribute/README.md
+++ b/rules/a11y-input-has-name-attribute/README.md
@@ -4,7 +4,7 @@
   - 入力要素は name を設定することでブラウザの補完機能が有効になる可能性が高まります。
     - 補完機能はブラウザによって異なるため、補完される可能性が上がるよう、name には半角英数の小文字・大文字と一部記号(`_ , [, ]`)のみ利用可能です。
   - input[type="radio"] は name を適切に設定することでラジオグループが確立され、キーボード操作しやすくなる等のメリットがあります。
-- checkTypeオプションに 'smart' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
+- checkTypeオプションに 'allow-spread-attributes' を指定することで spread attributeが設定されている場合はcorrectに出来ます。
 
 ## rules
 
@@ -13,7 +13,7 @@
   rules: {
     'smarthr/a11y-input-has-name-attribute': [
       'error', // 'warn', 'off'
-      // { checkType: 'always' } /* 'always' || 'smart' */
+      // { checkType: 'always' } /* 'always' || 'allow-spread-attributes' */
     ]
   },
 }
@@ -51,7 +51,7 @@ const StyledPiyo = styled(RadioButton)``;
 <Textarea name="some" />
 <Select name="piyo" />
 
-// checkType: 'smart'
+// checkType: 'allow-spread-attributes'
 <AnyInput {...args} />
 <AnyInput {...args} any="any" />
 ```

--- a/rules/a11y-input-has-name-attribute/index.js
+++ b/rules/a11y-input-has-name-attribute/index.js
@@ -34,7 +34,7 @@ const SCHEMA = [
   {
     type: 'object',
     properties: {
-      checkType: { type: 'string', enum: ['always', 'smart'], default: 'always' },
+      checkType: { type: 'string', enum: ['always', 'allow-spread-attributes'], default: 'always' },
     },
     additionalProperties: false,
   }
@@ -60,7 +60,7 @@ module.exports = {
           if (!nameAttr) {
             if (
               node.attributes.length === 0 ||
-              checkType !== 'smart' ||
+              checkType !== 'allow-spread-attributes' ||
               !node.attributes.some(findSpreadAttr)
             ) {
               const isRadio =

--- a/test/a11y-anchor-has-href-attribute.js
+++ b/test/a11y-anchor-has-href-attribute.js
@@ -37,7 +37,7 @@ ruleTester.run('a11y-anchor-has-href-attribute', rule, {
     { code: `<HogeAnchor href={hoge}>ほげ</HogeAnchor>` },
     { code: `<Link href="hoge">ほげ</Link>` },
     { code: `<Link href="#fuga">ほげ</Link>` },
-    { code: '<AnyAnchor {...args1} />', options: [{ checkType: 'smart' }] },
+    { code: '<AnyAnchor {...args1} />', options: [{ checkType: 'allow-spread-attributes' }] },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },

--- a/test/a11y-image-has-alt-attribute.js
+++ b/test/a11y-image-has-alt-attribute.js
@@ -45,7 +45,7 @@ ruleTester.run('a11y-image-has-alt-attribute', rule, {
     { code: '<HogeImage aria-describedby="hoge" />' },
     { code: '<HogeImage aria-describedby="hoge" alt="fuga" />' },
     { code: '<svg><image /></svg>' },
-    { code: '<AnyImg {...hoge} />', options: [{ checkType: 'smart' }] },
+    { code: '<AnyImg {...hoge} />', options: [{ checkType: 'allow-spread-attributes' }] },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },

--- a/test/a11y-input-has-name-attribute.js
+++ b/test/a11y-input-has-name-attribute.js
@@ -46,9 +46,9 @@ ruleTester.run('a11y-input-has-name-attribute', rule, {
     { code: '<HogeTextarea name="hoge" />' },
     { code: '<select name="hoge" />' },
     { code: '<Select name="hoge[0][Fuga]" />' },
-    { code: '<Input {...hoge} />', options: [{ checkType: 'smart' }] },
-    { code: '<Input {...args1} {...args2} />', options: [{ checkType: 'smart' }] },
-    { code: '<Input {...args} hoge="fuga" />', options: [{ checkType: 'smart' }] },
+    { code: '<Input {...hoge} />', options: [{ checkType: 'allow-spread-attributes' }] },
+    { code: '<Input {...args1} {...args2} />', options: [{ checkType: 'allow-spread-attributes' }] },
+    { code: '<Input {...args} hoge="fuga" />', options: [{ checkType: 'allow-spread-attributes' }] },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },


### PR DESCRIPTION
- smartオプションではルールの実体が分かりづらかったため、allow-spread-attributesに変更します