### PR TITLE
feat: a11y-replace-unreadable-symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [a11y-numbered-text-within-ol](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-numbered-text-within-ol)
 - [a11y-prohibit-input-placeholder](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-prohibit-input-placeholder)
 - [a11y-prohibit-useless-sectioning-fragment](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-prohibit-useless-sectioning-fragment)
+- [a11y-replace-unreadable-symbol](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-replace-unreadable-symbol)
 - [a11y-trigger-has-button](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-trigger-has-button)
 - [best-practice-for-button-element](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/best-practice-for-button-element)
 - [best-practice-for-date](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/best-practice-for-date)

--- a/rules/a11y-replace-unreadable-symbol/README.md
+++ b/rules/a11y-replace-unreadable-symbol/README.md
@@ -1,0 +1,38 @@
+# smarthr/a11y-replace-unreadable-symbol
+
+- 一部記号はスクリーンリーダーで読み上げられない、もしくは記号名そのままで読み上げられてしまい、意図が正しく伝えられない場合があります
+- それらの記号を適切に読み上げられるコンポーネントに置き換えることを促すルールです
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/a11y-replace-unreadable-symbol': 'error', // 'warn', 'off',
+  },
+}
+```
+
+## ❌ Incorrect
+
+```jsx
+<>XXXX年YY月ZZ日 〜 XXXX年YY月ZZ日</>
+// スクリーンリーダーは "XXXX年YY月ZZ日XXXX年YY月ZZ日" と読み上げる場合があります
+
+<p>選択できる数値の範囲は 0 ~ 9999 です</p>
+// スクリーンリーダーは "選択できる数値の範囲は09999です" と読み上げる場合があります
+```
+
+## ✅ Correct
+
+```jsx
+//
+<>XXXX年YY月ZZ日 <RangeSeparator /> XXXX年YY月ZZ日</>
+// スクリーンリーダーは "XXXX年YY月ZZ日からXXXX年YY月ZZ日" と読み上げます
+
+<p>選択できる数値の範囲は 0 <RangeSeparator /> 9999 です</p>
+// スクリーンリーダーは "選択できる数値の範囲は0から9999です" と読み上げます
+
+<p>入力できる記号は <RangeSeparator decorators={{ text: '~', visuallyHiddenText: '半角チルダ' }} /> です</p>
+// スクリーンリーダーは "入力できる記号は半角チルダです" と読み上げます
+```

--- a/rules/a11y-replace-unreadable-symbol/index.js
+++ b/rules/a11y-replace-unreadable-symbol/index.js
@@ -1,0 +1,28 @@
+const TILDE_REGEX = /([~〜])/
+
+const SCHEMA = []
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    schema: SCHEMA,
+  },
+  create(context) {
+    return {
+      JSXText: (node) => {
+        const matcher = node.value.match(TILDE_REGEX)
+
+        if (matcher) {
+          context.report({
+            node,
+            message: `"${matcher[1]}"はスクリーンリーダーが正しく読み上げることができない場合があるため、smarthr-ui/RangeSeparatorに置き換えてください。
+ - エラー表示されている行に"${matcher[1]}"が存在しない場合、改行文字を含む関係で行番号がずれている場合があります。数行下の範囲を確認してください
+ - smarthr-ui/RangeSeparatorに置き換えることでスクリーンリーダーが "から" と読み上げることができます
+ - 前後の文脈などで "から" と読まれることが不適切な場合 \`<RangeSeparator decorators={{ visuallyHiddenText: () => "ANY" }} />\` のようにdecoratorsを指定してください`,
+          })
+        }
+      },
+    }
+  },
+}
+module.exports.schema = SCHEMA

--- a/test/a11y-replace-unreadable-symbol.js
+++ b/test/a11y-replace-unreadable-symbol.js
@@ -1,0 +1,36 @@
+const rule = require('../rules/a11y-replace-unreadable-symbol')
+const RuleTester = require('eslint').RuleTester
+
+const generateErrorText = (symbol, replaced, read) => `"${symbol}"はスクリーンリーダーが正しく読み上げることができない場合があるため、smarthr-ui/${replaced}に置き換えてください。
+ - エラー表示されている行に"${symbol}"が存在しない場合、改行文字を含む関係で行番号がずれている場合があります。数行下の範囲を確認してください
+ - smarthr-ui/${replaced}に置き換えることでスクリーンリーダーが "${read}" と読み上げることができます
+ - 前後の文脈などで "${read}" と読まれることが不適切な場合 \`<RangeSeparator decorators={{ visuallyHiddenText: () => "ANY" }} />\` のようにdecoratorsを指定してください`
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('a11y-replace-unreadable-symbol', rule, {
+  valid: [
+    { code: `<>ほげふが</>` },
+    { code: `<RangeSeparator />` },
+    { code: `<p>ほげ<RangeSeparator />ふが</p>` },
+    { code: `<p>
+      ほげ
+      <RangeSeparator />
+      ふが
+    </p>` },
+  ],
+  invalid: [
+    { code: `<>~</>`, errors: [ { message: generateErrorText('~', 'RangeSeparator', 'から') } ] },
+    { code: `<>ほげ~ふが</>`, errors: [ { message: generateErrorText('~', 'RangeSeparator', 'から') } ] },
+    { code: `<p>ほげ〜ふが</p>`, errors: [ { message: generateErrorText('〜', 'RangeSeparator', 'から') } ] },
+  ]
+})


### PR DESCRIPTION
- 一部記号はスクリーンリーダーで読み上げられない、もしくは記号名そのままで読み上げられてしまい、意図が正しく伝えられない場合があります
- それらの記号を適切に読み上げられるコンポーネントに置き換えることを促すルールです