### PR TITLE
feat: a11y-prohibit-input-maxlength-attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [a11y-input-has-name-attribute](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-input-has-name-attribute)
 - [a11y-input-in-form-control](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-input-in-form-control)
 - [a11y-numbered-text-within-ol](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-numbered-text-within-ol)
+- [a11y-prohibit-input-maxlength-attribute](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-prohibit-input-maxlength-attribute)
 - [a11y-prohibit-input-placeholder](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-prohibit-input-placeholder)
 - [a11y-prohibit-useless-sectioning-fragment](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-prohibit-useless-sectioning-fragment)
 - [a11y-replace-unreadable-symbol](https://github.com/kufu/eslint-plugin-smarthr/tree/main/rules/a11y-replace-unreadable-symbol)

--- a/rules/a11y-prohibit-input-maxlength-attribute/README.md
+++ b/rules/a11y-prohibit-input-maxlength-attribute/README.md
@@ -1,6 +1,6 @@
 # smarthr/a11y-prohibit-input-maxlength-attribute
 
-- input, textlint 要素に maxLength 属性を設定することを禁止するルールです
+- input, textarea 要素に maxLength 属性を設定することを禁止するルールです
   - maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
 - maxLength 属性ではなく、pattern 属性と title 属性を組み合わせて form 要素でラップすることで、入力時でなく、submit 時にバリデーションすることができます。
 

--- a/rules/a11y-prohibit-input-maxlength-attribute/README.md
+++ b/rules/a11y-prohibit-input-maxlength-attribute/README.md
@@ -19,10 +19,10 @@
 ## ❌ Incorrect
 
 ```jsx
-<input maxLength="30" />
-<XxxInput maxLength="40" />
-<textarea maxLength="50" />
-<XxxTextarea maxLength="60" />
+<input maxLength={30} />
+<XxxInput maxLength={40} />
+<textarea maxLength={50} />
+<XxxTextarea maxLength={60} />
 ```
 
 ## ✅ Correct

--- a/rules/a11y-prohibit-input-maxlength-attribute/README.md
+++ b/rules/a11y-prohibit-input-maxlength-attribute/README.md
@@ -1,0 +1,57 @@
+# smarthr/a11y-prohibit-input-maxlength-attribute
+
+TODO: ここを書く
+
+- a, Anchor, Link コンポーネントに href 属性を設定することを促すルールです
+  - href が設定されていないanchor要素は `遷移先が存在しない無効化されたリンク` という扱いになります
+  - URLの変更を行わない場合、責務としても a より button が適切です
+  - URL遷移を行う場合、hrefが設定されていないとキーボード操作やコンテキストメニューからの遷移ができなくなります
+    - これらの操作は href属性を参照します
+  - 無効化されたリンクであることを表したい場合 `href={undefined}` を設定してください
+- checkTypeオプションに 'allow-spread-attributes' を指定することで spread attributeが設定されている場合はcorrectに出来ます
+- react-router-dom packageを利用している場合、a要素にto属性が指定されている場合、href属性が指定されているものとして許容します
+- next/link コンポーネント直下のa要素にhref属性が指定されていないことを許容します
+
+## rules
+
+```js
+{
+  rules: {
+    'smarthr/a11y-prohibit-input-maxlength-attribute': [
+      'error', // 'warn', 'off'
+      // { checkType: 'always' } /* 'always' || 'allow-spread-attributes' */
+    ]
+  },
+}
+```
+
+## ❌ Incorrect
+
+```jsx
+<a>any</a>
+<XxxAnchor>any</XxxAnchor>
+<XxxLink>any</XxxLink>
+<XxxLink href>any</XxxLink>
+
+// checkType: 'always'
+<XxxAnchor {...args} />
+<XxxLink {...args} any="any" />
+```
+
+## ✅ Correct
+
+```jsx
+<a href="https://www.google.com/search">any</a>
+<XxxAnchor href={hoge}>any</XxxAnchor>
+<XxxLink href={undefined}>any</XxxLink>
+
+// nextを利用している場合
+<Link href={hoge}><a>any</a></Link>
+
+// react-router-domを利用している場合
+<Link to={hoge}>any</Link>
+
+// checkType: 'allow-spread-attributes'
+<XxxAnchor {...args} />
+<XxxLink {...args} any="any" />
+```

--- a/rules/a11y-prohibit-input-maxlength-attribute/README.md
+++ b/rules/a11y-prohibit-input-maxlength-attribute/README.md
@@ -1,16 +1,8 @@
 # smarthr/a11y-prohibit-input-maxlength-attribute
 
-TODO: ここを書く
-
-- a, Anchor, Link コンポーネントに href 属性を設定することを促すルールです
-  - href が設定されていないanchor要素は `遷移先が存在しない無効化されたリンク` という扱いになります
-  - URLの変更を行わない場合、責務としても a より button が適切です
-  - URL遷移を行う場合、hrefが設定されていないとキーボード操作やコンテキストメニューからの遷移ができなくなります
-    - これらの操作は href属性を参照します
-  - 無効化されたリンクであることを表したい場合 `href={undefined}` を設定してください
-- checkTypeオプションに 'allow-spread-attributes' を指定することで spread attributeが設定されている場合はcorrectに出来ます
-- react-router-dom packageを利用している場合、a要素にto属性が指定されている場合、href属性が指定されているものとして許容します
-- next/link コンポーネント直下のa要素にhref属性が指定されていないことを許容します
+- input, textlint 要素に maxLength 属性を設定することを禁止するルールです
+  - maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
+- maxLength 属性ではなく、pattern 属性と title 属性を組み合わせて form 要素でラップすることで、入力時でなく、submit 時にバリデーションすることができます。
 
 ## rules
 
@@ -19,7 +11,6 @@ TODO: ここを書く
   rules: {
     'smarthr/a11y-prohibit-input-maxlength-attribute': [
       'error', // 'warn', 'off'
-      // { checkType: 'always' } /* 'always' || 'allow-spread-attributes' */
     ]
   },
 }
@@ -28,30 +19,17 @@ TODO: ここを書く
 ## ❌ Incorrect
 
 ```jsx
-<a>any</a>
-<XxxAnchor>any</XxxAnchor>
-<XxxLink>any</XxxLink>
-<XxxLink href>any</XxxLink>
-
-// checkType: 'always'
-<XxxAnchor {...args} />
-<XxxLink {...args} any="any" />
+<input maxLength="30" />
+<XxxInput maxLength="40" />
+<textarea maxLength="50" />
+<XxxTextarea maxLength="60" />
 ```
 
 ## ✅ Correct
 
 ```jsx
-<a href="https://www.google.com/search">any</a>
-<XxxAnchor href={hoge}>any</XxxAnchor>
-<XxxLink href={undefined}>any</XxxLink>
-
-// nextを利用している場合
-<Link href={hoge}><a>any</a></Link>
-
-// react-router-domを利用している場合
-<Link to={hoge}>any</Link>
-
-// checkType: 'allow-spread-attributes'
-<XxxAnchor {...args} />
-<XxxLink {...args} any="any" />
+<input />
+<XxxInput />
+<textarea />
+<XxxTextarea />
 ```

--- a/rules/a11y-prohibit-input-maxlength-attribute/README.md
+++ b/rules/a11y-prohibit-input-maxlength-attribute/README.md
@@ -1,7 +1,7 @@
 # smarthr/a11y-prohibit-input-maxlength-attribute
 
 - input, textarea 要素に maxLength 属性を設定することを禁止するルールです
-  - maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
+  - maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合があります。
 - maxLength 属性ではなく、pattern 属性と title 属性を組み合わせて form 要素でラップすることで、入力時でなく、submit 時にバリデーションすることができます。
 
 ## rules

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -27,9 +27,11 @@ module.exports = {
           if (maxLengthAttr) {
             context.report({
               node,
-              message: `input要素にはmaxLength属性を設定しないでください。
-pattern属性とtitle属性を組み合わせ、form要素でラップするか、JavaScriptでバリデーションしてください。
-              `,
+              message: `input要素及びtextarea要素にmaxLength属性を設定しないでください。
+- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
+- 以下のいずれかの方法で修正をおこなってください
+  - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
+  - 方法2: JavaScriptを用いたバリデーションを実装する`,
             })
           }
         }

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -23,8 +23,7 @@ module.exports = {
     return {
       ...generateTagFormatter({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }),
       JSXOpeningElement: (node) => {
-        const name = node.name?.name
-        if (name && INPUT_COMPONENT_NAMES.test(name)) {
+        if (node.name.type === 'JSXIdentifier' && INPUT_COMPONENT_NAMES.test(node.name.name)) {
           const attributes = node.attributes
           const maxLengthAttr = attributes.find(a => a.name?.name === 'maxLength')
           if (maxLengthAttr) {

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -30,7 +30,7 @@ module.exports = {
             context.report({
               node,
               message: `input要素及びtextarea要素にmaxLength属性を設定しないでください。
-- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
+- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合がある
 - 以下のいずれかの方法で修正をおこなってください
   - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
   - 方法2: JavaScriptを用いたバリデーションを実装する`,

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -29,7 +29,7 @@ module.exports = {
           if (maxLengthAttr) {
             context.report({
               node,
-              message: `input要素及びtextarea要素にmaxLength属性を設定しないでください。
+              message: `${node.name.name}にmaxLength属性を設定しないでください。
 - maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合がある
 - 以下のいずれかの方法で修正をおこなってください
   - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -1,0 +1,40 @@
+const { generateTagFormatter } = require('../../libs/format_styled_components')
+
+const EXPECTED_NAMES = {
+  '(Input|^input)$': '(Input)$',
+  '(Textarea|^textarea)$': '(Textarea)$',
+}
+
+const UNEXPECTED_NAMES = EXPECTED_NAMES
+
+const INPUT_COMPONENT_NAMES = new RegExp(`(${Object.keys(EXPECTED_NAMES).join('|')})`)
+
+const SCHEMA = []
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    schema: SCHEMA,
+  },
+  create(context) {
+    return {
+      ...generateTagFormatter({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }),
+      JSXOpeningElement: (node) => {
+        const name = node.name?.name
+        if (name && INPUT_COMPONENT_NAMES.test(name)) {
+          const attributes = node.attributes
+          const maxLengthAttr = attributes.find(a => a.name?.name === 'maxLength')
+          if (maxLengthAttr) {
+            context.report({
+              node,
+              message: `input要素にはmaxLength属性を設定しないでください。
+pattern属性とtitle属性を組み合わせ、form要素でラップするか、JavaScriptでバリデーションしてください。
+              `,
+            })
+          }
+        }
+      },
+    }
+  },
+}
+module.exports.schema = SCHEMA

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -30,7 +30,7 @@ module.exports = {
             context.report({
               node,
               message: `${node.name.name}にmaxLength属性を設定しないでください。
-- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合がある
+- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合があります
 - 以下のいずれかの方法で修正をおこなってください
   - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
   - 方法2: JavaScriptを用いたバリデーションを実装する`,

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -11,6 +11,9 @@ const INPUT_COMPONENT_NAMES = new RegExp(`(${Object.keys(EXPECTED_NAMES).join('|
 
 const SCHEMA = []
 
+/**
+ * @type {import('@typescript-eslint/utils').TSESLint.RuleModule<''>}
+ */
 module.exports = {
   meta: {
     type: 'problem',

--- a/rules/a11y-prohibit-input-maxlength-attribute/index.js
+++ b/rules/a11y-prohibit-input-maxlength-attribute/index.js
@@ -24,8 +24,8 @@ module.exports = {
       ...generateTagFormatter({ context, EXPECTED_NAMES, UNEXPECTED_NAMES }),
       JSXOpeningElement: (node) => {
         if (node.name.type === 'JSXIdentifier' && INPUT_COMPONENT_NAMES.test(node.name.name)) {
-          const attributes = node.attributes
-          const maxLengthAttr = attributes.find(a => a.name?.name === 'maxLength')
+          const checkHasMaxLength = (attr) => attr.name?.name === 'maxLength'
+          const maxLengthAttr = node.attributes.find(checkHasMaxLength)
           if (maxLengthAttr) {
             context.report({
               node,

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -25,7 +25,8 @@ ruleTester.run('a11y-prohibit-input-maxlength-attribute', rule, {
     { code: `<HogeInput value="hoge" />` },
     { code: `<textarea>hoge</textarea>` },
     { code: `<Textarea type="text" />` },
-    { code: `<HogeTextarea value="hoge" />` }
+    { code: `<HogeTextarea value="hoge" />` },
+    { code: `<><input /></>`}
   ],
   invalid: [
     { code: `<input maxLength={30} />`, errors: [{ message: expectedErrorMessage('input') }] },

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -1,0 +1,32 @@
+const rule = require('../rules/a11y-prohibit-input-maxlength-attribute')
+const RuleTester = require('eslint').RuleTester
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 12,
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
+    },
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('a11y-prohibit-input-maxlength-attribute', rule, {
+  valid: [
+    { code: `<input />` },
+    { code: `<Input type="text" />` },
+    { code: `<HogeInput value="hoge" />` },
+    { code: `<textarea>hoge</textarea>` },
+    { code: `<Textarea type="text" />` },
+    { code: `<HogeTextarea value="hoge" />` }
+  ],
+  invalid: [
+    { code: `<input maxLength="30" />`, errors: [{ message: 'input要素にはmaxLength属性を設定しないでください' }] },
+    { code: `<Input type="text" />` },
+    { code: `<HogeInput value="hoge" />` },
+    { code: `<textarea>hoge</textarea>` },
+    { code: `<Textarea type="text" />` },
+    { code: `<HogeTextarea value="hoge" />` }
+  ]
+})

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -13,7 +13,7 @@ const ruleTester = new RuleTester({
 })
 
 const expectedErrorMessage = `input要素及びtextarea要素にmaxLength属性を設定しないでください。
-- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
+- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合がある
 - 以下のいずれかの方法で修正をおこなってください
   - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
   - 方法2: JavaScriptを用いたバリデーションを実装する`

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -28,11 +28,11 @@ ruleTester.run('a11y-prohibit-input-maxlength-attribute', rule, {
     { code: `<HogeTextarea value="hoge" />` }
   ],
   invalid: [
-    { code: `<input maxLength="30" />`, errors: [{ message: expectedErrorMessage }] },
-    { code: `<Input type="text" maxLength="40" />`, errors: [{ message: expectedErrorMessage }] },
+    { code: `<input maxLength={30} />`, errors: [{ message: expectedErrorMessage }] },
+    { code: `<Input type="text" maxLength={40} />`, errors: [{ message: expectedErrorMessage }] },
     { code: `<HogeInput maxLength value="hoge" />`, errors: [{ message: expectedErrorMessage }] },
-    { code: `<textarea maxLength="50">hoge</textarea>`, errors: [{ message: expectedErrorMessage }]},
-    { code: `<Textarea type="text" maxLength="60" />`, errors: [{ message: expectedErrorMessage }]},
-    { code: `<HogeTextarea maxLength="70" value="hoge" />`, errors: [{ message: expectedErrorMessage }]}
+    { code: `<textarea maxLength={50}>hoge</textarea>`, errors: [{ message: expectedErrorMessage }]},
+    { code: `<Textarea type="text" maxLength={60} />`, errors: [{ message: expectedErrorMessage }]},
+    { code: `<HogeTextarea maxLength={70} value="hoge" />`, errors: [{ message: expectedErrorMessage }]}
   ]
 })

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -13,7 +13,7 @@ const ruleTester = new RuleTester({
 })
 
 const expectedErrorMessage = (elName) => `${elName}にmaxLength属性を設定しないでください。
-- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合がある
+- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合があります
 - 以下のいずれかの方法で修正をおこなってください
   - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
   - 方法2: JavaScriptを用いたバリデーションを実装する`

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -12,6 +12,12 @@ const ruleTester = new RuleTester({
   },
 })
 
+const expectedErrorMessage = `input要素及びtextarea要素にmaxLength属性を設定しないでください。
+- maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまいます。
+- 以下のいずれかの方法で修正をおこなってください
+  - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
+  - 方法2: JavaScriptを用いたバリデーションを実装する`
+
 ruleTester.run('a11y-prohibit-input-maxlength-attribute', rule, {
   valid: [
     { code: `<input />` },
@@ -22,11 +28,11 @@ ruleTester.run('a11y-prohibit-input-maxlength-attribute', rule, {
     { code: `<HogeTextarea value="hoge" />` }
   ],
   invalid: [
-    { code: `<input maxLength="30" />`, errors: [{ message: 'input要素にはmaxLength属性を設定しないでください' }] },
-    { code: `<Input type="text" />` },
-    { code: `<HogeInput value="hoge" />` },
-    { code: `<textarea>hoge</textarea>` },
-    { code: `<Textarea type="text" />` },
-    { code: `<HogeTextarea value="hoge" />` }
+    { code: `<input maxLength="30" />`, errors: [{ message: expectedErrorMessage }] },
+    { code: `<Input type="text" maxLength="40" />`, errors: [{ message: expectedErrorMessage }] },
+    { code: `<HogeInput maxLength value="hoge" />`, errors: [{ message: expectedErrorMessage }] },
+    { code: `<textarea maxLength="50">hoge</textarea>`, errors: [{ message: expectedErrorMessage }]},
+    { code: `<Textarea type="text" maxLength="60" />`, errors: [{ message: expectedErrorMessage }]},
+    { code: `<HogeTextarea maxLength="70" value="hoge" />`, errors: [{ message: expectedErrorMessage }]}
   ]
 })

--- a/test/a11y-prohibit-input-maxlength-attribute.js
+++ b/test/a11y-prohibit-input-maxlength-attribute.js
@@ -12,7 +12,7 @@ const ruleTester = new RuleTester({
   },
 })
 
-const expectedErrorMessage = `input要素及びtextarea要素にmaxLength属性を設定しないでください。
+const expectedErrorMessage = (elName) => `${elName}にmaxLength属性を設定しないでください。
 - maxLength属性がついた要素に、テキストをペーストすると、maxLength属性の値を超えた範囲が意図せず切り捨てられてしまう場合がある
 - 以下のいずれかの方法で修正をおこなってください
   - 方法1: pattern属性とtitle属性を組み合わせ、form要素でラップする
@@ -28,11 +28,11 @@ ruleTester.run('a11y-prohibit-input-maxlength-attribute', rule, {
     { code: `<HogeTextarea value="hoge" />` }
   ],
   invalid: [
-    { code: `<input maxLength={30} />`, errors: [{ message: expectedErrorMessage }] },
-    { code: `<Input type="text" maxLength={40} />`, errors: [{ message: expectedErrorMessage }] },
-    { code: `<HogeInput maxLength value="hoge" />`, errors: [{ message: expectedErrorMessage }] },
-    { code: `<textarea maxLength={50}>hoge</textarea>`, errors: [{ message: expectedErrorMessage }]},
-    { code: `<Textarea type="text" maxLength={60} />`, errors: [{ message: expectedErrorMessage }]},
-    { code: `<HogeTextarea maxLength={70} value="hoge" />`, errors: [{ message: expectedErrorMessage }]}
+    { code: `<input maxLength={30} />`, errors: [{ message: expectedErrorMessage('input') }] },
+    { code: `<Input type="text" maxLength={40} />`, errors: [{ message: expectedErrorMessage('Input') }] },
+    { code: `<HogeInput maxLength value="hoge" />`, errors: [{ message: expectedErrorMessage('HogeInput') }] },
+    { code: `<textarea maxLength={50}>hoge</textarea>`, errors: [{ message: expectedErrorMessage('textarea') }]},
+    { code: `<Textarea type="text" maxLength={60} />`, errors: [{ message: expectedErrorMessage('Textarea') }]},
+    { code: `<HogeTextarea maxLength={70} value="hoge" />`, errors: [{ message: expectedErrorMessage('HogeTextarea') }]}
   ]
 })


### PR DESCRIPTION
# WHAT

`<input>` `<textarea>` 及びその拡張コンポーネントに対する `maxLength` 属性の使用を禁止するルール (`a11y-prohibit-input-maxlength-attribute`) を追加します。

# WHY

`maxlength` は、テキストをコピペした際に制限以上の文字列が勝手に切り捨てられる使用でユーザビリティ・アクセシビリティ上の問題があるため

# HOW

関連ルールを模倣しながら、モブプロで実装するなど

# Capture

プロダクト側に反映させて、正しく検知できることを確認。
![CleanShot 2024-04-08 at 16 03 37](https://github.com/kufu/eslint-plugin-smarthr/assets/16274215/b7450fd1-07e6-4824-a630-b1315d8b8862)

