### PR TITLE
feat: best-practice-for-layoutsでStackコンポーネントにgap={0}が指定されている場合、適切に置き換え・または削除を促すように修正

### DIFF
--- a/rules/best-practice-for-layouts/index.js
+++ b/rules/best-practice-for-layouts/index.js
@@ -24,9 +24,6 @@ const checkFalsyJSXText = (c) => (
   )
 )
 
-const findJustifyAttr = (a) => a.name?.name === 'justify'
-const findAlignAttr = (a) => a.name?.name === 'align'
-
 const searchChildren = (node) => {
   if (
     node.type === 'JSXFragment' ||
@@ -74,27 +71,56 @@ module.exports = {
           const matcher = nodeName.match(MULTI_CHILDREN_REGEX)
 
           if (matcher) {
+            const layoutType = matcher[1]
+            let justifyAttr = null
+            let alignAttr = null
+            let gapAttr = null
+
+            node.attributes.forEach((a) => {
+              switch (a.name?.name) {
+                case 'justify':
+                  justifyAttr = a
+                  break
+                case 'align':
+                  alignAttr = a
+                  break
+                case 'gap':
+                  gapAttr = a
+                  break
+              }
+            })
+
+            if (layoutType === 'Stack') {
+              if (alignAttr && FLEX_END_REGEX.test(alignAttr.value.value)) {
+                return
+              } else if (gapAttr?.value.type === 'JSXExpressionContainer' && gapAttr.value.expression.value === 0) {
+                context.report({
+                  node,
+                  message: `${nodeName} に "gap={0}" が指定されており、smarthr-ui/${layoutType} の利用方法として誤っている可能性があります。以下の修正方法を検討してください。
+ - 方法1: 子要素を一つにまとめられないか検討してください
+   - 例: "<Stack gap={0}><p>hoge</p><p>fuga</p></Stack>" を "<p>hoge<br />fuga</p>" にするなど
+ - 方法2: 子要素のstyleを確認しgap属性を0以外にできないか検討してください
+   - 子要素が個別に持っているmarginなどのstyleを${nodeName}のgap属性で共通化できないか確認してください
+ - 方法3: 別要素でマークアップし直すか、${nodeName}を削除してください
+   - 親要素に smarthr-ui/Cluster, smarthr-ui/Stack などが存在している場合、div・spanなどで1要素にまとめる必要がある場合があります
+   - as, forwardedAsなどでSectioningContent系要素に変更している場合、対応するsmarthr-ui/Section, Aside, Nav, Article のいずれかに差し替えてください`
+                })
+              }
+            }
+
             const children = node.parent.children.filter(checkFalsyJSXText)
 
             if (children.length === 1) {
-              const layoutType = matcher[1]
-              const justifyAttr = layoutType === 'Cluster' ? node.attributes.find(findJustifyAttr) : null
-
               if (justifyAttr && FLEX_END_REGEX.test(justifyAttr.value.value)) {
                 return
               }
 
-              const alignAttr = layoutType === 'Stack' ? node.attributes.find(findAlignAttr) : null
-
-              if (alignAttr && FLEX_END_REGEX.test(alignAttr.value.value)) {
-                return
-              }
 
               if (searchChildren(children[0])) {
                 context.report({
                   node,
                   message:
-                    (justifyAttr && justifyAttr.value.value === 'center' || alignAttr && alignAttr.value.value === 'center')
+                    (justifyAttr?.value.value === 'center' || alignAttr?.value.value === 'center')
                       ? `${nodeName} は smarthr-ui/${layoutType} ではなく smarthr-ui/Center でマークアップしてください`
                       : `${nodeName}には子要素が一つしか無いため、${layoutType}でマークアップする意味がありません。
  - styleを確認し、div・spanなど、別要素でマークアップし直すか、${nodeName}を削除してください

--- a/test/best-practice-for-layouts.js
+++ b/test/best-practice-for-layouts.js
@@ -54,7 +54,7 @@ ruleTester.run('best-practice-for-button-element', rule, {
     { code: `<AnyCluster>{a ? <Hoge /> : a.b.map(action)}</AnyCluster>` },
     { code: `<AnyCluster>{a ? <Hoge /> : a ? <Hoge /> : a.b.map(action)}</AnyCluster>` },
     { code: `<Cluster justify="flex-end">{a}</Cluster>` },
-    { code: `<HogeCluster justify="end">{a}</HogeCluster>` },
+    { code: `<HogeCluster justify="end" gap={0}>{a}</HogeCluster>` },
     { code: `<Stack align="flex-end">{a}</Stack>` },
     { code: `<HogeStack align="end">{a}</HogeStack>` },
   ],
@@ -85,6 +85,14 @@ ruleTester.run('best-practice-for-button-element', rule, {
     { code: `<AnyCluster>{a ? <Hoge /> : a ? <Hoge /> : a.b.hoge(action)}</AnyCluster>`, errors: [ { message: errorMessage('Cluster', 'AnyCluster') } ] },
     { code: `<HogeCluster justify="center">{a}</HogeCluster>`, errors: [ { message: 'HogeCluster は smarthr-ui/Cluster ではなく smarthr-ui/Center でマークアップしてください' } ] },
     { code: `<HogeStack align="center">{a}</HogeStack>`, errors: [ { message: 'HogeStack は smarthr-ui/Stack ではなく smarthr-ui/Center でマークアップしてください' } ] },
+    { code: `<HogeStack gap={0}>{a}{b}</HogeStack>`, errors: [ { message: `HogeStack に "gap={0}" が指定されており、smarthr-ui/Stack の利用方法として誤っている可能性があります。以下の修正方法を検討してください。
+ - 方法1: 子要素を一つにまとめられないか検討してください
+   - 例: "<Stack gap={0}><p>hoge</p><p>fuga</p></Stack>" を "<p>hoge<br />fuga</p>" にするなど
+ - 方法2: 子要素のstyleを確認しgap属性を0以外にできないか検討してください
+   - 子要素が個別に持っているmarginなどのstyleをHogeStackのgap属性で共通化できないか確認してください
+ - 方法3: 別要素でマークアップし直すか、HogeStackを削除してください
+   - 親要素に smarthr-ui/Cluster, smarthr-ui/Stack などが存在している場合、div・spanなどで1要素にまとめる必要がある場合があります
+   - as, forwardedAsなどでSectioningContent系要素に変更している場合、対応するsmarthr-ui/Section, Aside, Nav, Article のいずれかに差し替えてください` } ] },
   ]
 })
 


### PR DESCRIPTION
Stackコンポーネントにgap={0}が指定されている場合、基本的にStackコンポーネントは無意味、もしくはdivで良いため、エラーにするようにします