### PR TITLE
fix:  <FormControl> 内に三項演算子がある場合に、入力要素が複数あると誤認されないようにする

### DIFF
--- a/rules/a11y-input-in-form-control/index.js
+++ b/rules/a11y-input-in-form-control/index.js
@@ -185,6 +185,7 @@ module.exports = {
  - 可能なら${nodeName}は${convertComp}への変更を検討してください。難しい場合は ${nodeName} と結びつくlabel要素が必ず存在するよう、マークアップする必要があることに注意してください。` : ''}`,
                         });
                       } else if (isMultiInput && !openingElement.attributes.find(findRoleGroup)) {
+                        if (node.parent?.parent?.type === 'ConditionalExpression') return;
                         context.report({
                           node: n,
                           message: `${name} が複数の入力要素を含んでいます。ラベルと入力要素の紐づけが正しく行われない可能性があるため、以下の方法のいずれかで修正してください。

--- a/rules/a11y-input-in-form-control/index.js
+++ b/rules/a11y-input-in-form-control/index.js
@@ -94,6 +94,7 @@ module.exports = {
     const checkAdditionalMultiInputComponents = (name) => additionalMultiInputComponents && name.match(additionalMultiInputComponents)
 
     let formControls = []
+    let conditionalformControls = []
     let checkboxFormControls = []
 
     return {
@@ -102,6 +103,7 @@ module.exports = {
         const nodeName = node.name.name || '';
         const isFormControlInput = nodeName.match(FORM_CONTROL_INPUTS_REGEX)
         const isAdditionalMultiInput = checkAdditionalMultiInputComponents(nodeName)
+        let conditionalExpressions = []
 
         if (isFormControlInput || isAdditionalMultiInput || checkAdditionalInputComponents(nodeName)) {
           let isInMap = false
@@ -162,12 +164,22 @@ module.exports = {
                 if (name) {
                   if (name.match(FROM_CONTROLS_REGEX)) {
                     const hit = formControls.includes(n)
+                    let conditionalHit = false
 
                     if (!hit) {
                       formControls.push(n)
 
+
                       if (isCheckbox) {
                         checkboxFormControls.push(n)
+                      }
+                    }
+
+                    if (conditionalExpressions.length > 0) {
+                      conditionalHit = conditionalformControls.includes(n)
+
+                      if (!conditionalHit) {
+                        conditionalformControls.push(n)
                       }
                     }
 
@@ -184,8 +196,7 @@ module.exports = {
  - Fieldsetで同じname属性のラジオボタン全てを囲むことで正しくグループ化され、適切なタイトル・説明を追加出来ます` : ''}${isPureInput ? `
  - 可能なら${nodeName}は${convertComp}への変更を検討してください。難しい場合は ${nodeName} と結びつくlabel要素が必ず存在するよう、マークアップする必要があることに注意してください。` : ''}`,
                         });
-                      } else if (isMultiInput && !openingElement.attributes.find(findRoleGroup)) {
-                        if (node.parent?.parent?.type === 'ConditionalExpression') return;
+                      } else if (isMultiInput && !conditionalHit && !openingElement.attributes.find(findRoleGroup)) {
                         context.report({
                           node: n,
                           message: `${name} が複数の入力要素を含んでいます。ラベルと入力要素の紐づけが正しく行われない可能性があるため、以下の方法のいずれかで修正してください。
@@ -244,6 +255,10 @@ module.exports = {
                   }
                 }
 
+                break
+              }
+              case 'ConditionalExpression': {
+                conditionalExpressions.push(n)
                 break
               }
               case 'VariableDeclarator': {

--- a/test/a11y-input-in-form-control.js
+++ b/test/a11y-input-in-form-control.js
@@ -135,7 +135,7 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<Fieldset><HogeRadioButtonPanels /></Fieldset>' },
     { code: '<Fieldset><HogeCheckBoxs /></Fieldset>' },
     { code: '<Fieldset><HogeCheckBoxes /></Fieldset>' },
-    { code: "<FormControl>{ dateInput ? <DateInput /> : <Input /> }</FormControl>" },
+    { code: '<HogeFormControl>{ dateInput ? <DateInput /> : <Input /> }</HogeFormControl>'},
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
@@ -180,6 +180,7 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<HogeFormControl><HogeRadioButtons /></HogeFormControl>', errors: [ { message: invalidRadioInFormControl('HogeRadioButtons') } ] },
     { code: '<HogeFormControl><HogeCheckBoxs /></HogeFormControl>', errors: [ { message: invalidMultiInputsInFormControl() } ] },
     { code: '<HogeFormControl><HogeCheckBoxes /></HogeFormControl>', errors: [ { message: invalidMultiInputsInFormControl() } ] },
-    // FIXME: { code: "<FormControl><CheckBox />{ dateInput ? <DateInput /> : <Input /> }</FormControl>", errors: [ { message: invalidMultiInputsInFormControl() } ]},
+    { code: "<HogeFormControl>{ dateInput ? <DateInput /> : <Input /> }<CheckBox /></HogeFormControl>", errors: [ { message: invalidMultiInputsInFormControl() } ]},
+    { code: "<HogeFormControl><CheckBox />{ dateInput ? <DateInput /> : <Input /> }</HogeFormControl>", errors: [ { message: invalidMultiInputsInFormControl() } ]},
   ]
 })

--- a/test/a11y-input-in-form-control.js
+++ b/test/a11y-input-in-form-control.js
@@ -135,6 +135,7 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<Fieldset><HogeRadioButtonPanels /></Fieldset>' },
     { code: '<Fieldset><HogeCheckBoxs /></Fieldset>' },
     { code: '<Fieldset><HogeCheckBoxes /></Fieldset>' },
+    { code: "<FormControl>{ dateInput ? <DateInput /> : <Input /> }</FormControl>" },
   ],
   invalid: [
     { code: `import hoge from 'styled-components'`, errors: [ { message: `styled-components をimportする際は、名称が"styled" となるようにしてください。例: "import styled from 'styled-components'"` } ] },
@@ -179,5 +180,6 @@ ruleTester.run('a11y-input-in-form-control', rule, {
     { code: '<HogeFormControl><HogeRadioButtons /></HogeFormControl>', errors: [ { message: invalidRadioInFormControl('HogeRadioButtons') } ] },
     { code: '<HogeFormControl><HogeCheckBoxs /></HogeFormControl>', errors: [ { message: invalidMultiInputsInFormControl() } ] },
     { code: '<HogeFormControl><HogeCheckBoxes /></HogeFormControl>', errors: [ { message: invalidMultiInputsInFormControl() } ] },
+    // FIXME: { code: "<FormControl><CheckBox />{ dateInput ? <DateInput /> : <Input /> }</FormControl>", errors: [ { message: invalidMultiInputsInFormControl() } ]},
   ]
 })


### PR DESCRIPTION
# WHAT

`a11y-input-in-form-control` のルールを修正し、三項演算子内の入力要素だった場合に、入力要素が複数あると誤認されないようにします。

# WHY

以下のようなコードで False Positive が発生する。

```tsx
<FormControl>
  { date ? <DateInput /> : <Input /> }
</FormControl>
```

実際は DateInput と Input どちらかしか描画されないが、FormControl 内に複数の入力要素があると警告が出てしまう。

# HOW

走査時に三項演算子の有無をチェックし、それに応じて入力要素数を正しく数えるようにする