### PR TITLE
fix: 適切にonClick属性を利用しているケースを通したい！

### DIFF
--- a/rules/a11y-delegate-element-has-role-presentation/index.js
+++ b/rules/a11y-delegate-element-has-role-presentation/index.js
@@ -31,6 +31,7 @@ const EXPECTED_NAMES = {
   'Pagination$': 'Pagination$',
   'SideNav$': 'SideNav$',
   'AccordionPanel$': 'AccordionPanel$',
+  'FilterDropdown$': 'FilterDropdown$',
 }
 
 const UNEXPECTED_NAMES = {


### PR DESCRIPTION
## What

* SmartHR UIの `FilterDropdown` コンポーネントを利用し `onClick` 属性に値を渡しても `smarthr/a11y-delegate-element-has-role-presentation` ルールに抵触しないようにしたいです

## Why

* `FilterDropdown` コンポーネントは内部的に `onClick` 属性の値を [`Button` コンポーネントにフォワーディングしています](https://github.com/kufu/smarthr-ui/blob/187f2d01b294fe8c6fc92575032fb2a09dbc98eb/packages/smarthr-ui/src/components/Dropdown/FilterDropdown/FilterDropdown.tsx#L146)
* 最終的にインタラクティブな要素に値が渡されている以上は本ルールの規制対象にならないと考えています

### How

* `smarthr/a11y-delegate-element-has-role-presentation` ルールが期待するコンポーネント名に `FilterDropdown` を追加しました

